### PR TITLE
Launch configuration naming, tagging fix/clarity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_autoscaling_group" "this" {
   count = "${var.create_asg}"
 
   name_prefix          = "${coalesce(var.asg_name, var.name)}-"
-  launch_configuration = "${var.create_lc ? element(concat(aws_launch_configuration.this.*.id, list(var.launch_configuration)), 0) : var.launch_configuration}"
+  launch_configuration = "${var.create_lc ? element(aws_launch_configuration.this.*.name, 0) : var.launch_configuration}"
   vpc_zone_identifier  = ["${var.vpc_zone_identifier}"]
   max_size             = "${var.max_size}"
   min_size             = "${var.min_size}"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_autoscaling_group" "this" {
   protect_from_scale_in     = "${var.protect_from_scale_in}"
 
   tags = ["${concat(
-      var.tags,
-      list(map("key", "Name", "value", var.name, "propagate_at_launch", true))
+      list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
+      var.tags
    )}"]
 }


### PR DESCRIPTION
 - add supplied tag blocks after name block so that all of the tags don't get rearranged every time one is added or removed.

- remove unneeded concat of var.launch_configuration into the launch_config name