### PR TITLE
Add lifecycle to aws_autoscaling_group resource also

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,10 @@ resource "aws_autoscaling_group" "this" {
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
   protect_from_scale_in     = "${var.protect_from_scale_in}"
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = ["${concat(
       list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
       var.tags


### PR DESCRIPTION
Multiple sources recommend having `create_before_destroy` on the ASG as well as the LC.

https://www.terraform.io/docs/providers/aws/r/launch_configuration.html

https://groups.google.com/forum/#!topic/terraform-tool/7Gdhv1OAc80