### PR TITLE
Add create_before_destroy to the autoscaling_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,4 +60,8 @@ resource "aws_autoscaling_group" "this" {
       list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
       var.tags
    )}"]
+  
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
Adding the `create_before_destroy` lifecycle configuration allows blue-green deployments, for example after building a new AMI, the following happens when you run `terraform apply`:

1. A new `launch_configuration` must be created for the new AMI
2. A new `autoscaling group` must me created (because you make it's name interpolate from that of the `launch_configuration`
3. `create_before_destroy = true` allows everything to be created and flipped over seamlessly 

Check out [this blog post](https://robmorgan.id.au/posts/rolling-deploys-on-aws-using-terraform/) for more info.