### PR TITLE
ref #12 #1 - resolve tagging format difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ module "asg" {
       propagate_at_launch = true
     },
   ]
+  
+  tags_as_map = {
+    extra_tag1             = "extra_value1"
+    extra_tag2             = "extra_value2"
+  }
 }
 ```
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,133 @@
+locals {
+  # This whole block is dedicated to converting an input variable of map (same type as other resources) into asg
+  # compatible format, which is a list of maps with the propagate_at_launch variable set at true.
+  # Split the full_tags variable (map) into 2 lists in same order as the map
+  tag_keys = "${keys(var.tags_as_map)}"
+
+  tag_values = "${values(var.tags_as_map)}"
+
+  list_blank = "${list()}"
+
+  # Define a structure for the keys of the dicts that the asg block requires.
+  key_list = "${list(
+    "key",
+    "value",
+    "propagate_at_launch")}"
+
+  # 10 lists containing values that will be zipmapped to the above structure later.
+  list0 = "${list(
+      element(local.tag_keys, 0) != "" ? element(local.tag_keys, 0) : "",
+      element(local.tag_values, 0) != "" ? element(local.tag_values, 0) : "",
+      "true"
+    )
+  }"
+
+  list1 = "${list(
+      element(local.tag_keys, 1) != "" ? element(local.tag_keys, 1) : "",
+      element(local.tag_values, 1) != "" ? element(local.tag_values, 1) : "",
+      "true"
+    )
+  }"
+
+  list2 = "${list(
+      element(local.tag_keys, 2) != "" ? element(local.tag_keys, 2) : "",
+      element(local.tag_values, 2) != "" ? element(local.tag_values, 2) : "",
+      "true"
+    )
+  }"
+
+  list3 = "${list(
+      element(local.tag_keys, 3) != "" ? element(local.tag_keys, 3) : "",
+      element(local.tag_values, 3) != "" ? element(local.tag_values, 3) : "",
+      "true"
+    )
+  }"
+
+  list4 = "${list(
+      element(local.tag_keys, 4) != "" ? element(local.tag_keys, 4) : "",
+      element(local.tag_values, 4) != "" ? element(local.tag_values, 4) : "",
+      "true"
+    )
+  }"
+
+  list5 = "${list(
+      element(local.tag_keys, 5) != "" ? element(local.tag_keys, 5) : "",
+      element(local.tag_values, 5) != "" ? element(local.tag_values, 5) : "",
+      "true"
+    )
+  }"
+
+  list6 = "${list(
+      element(local.tag_keys, 6) != "" ? element(local.tag_keys, 6) : "",
+      element(local.tag_values, 6) != "" ? element(local.tag_values, 6) : "",
+      "true"
+    )
+  }"
+
+  list7 = "${list(
+      element(local.tag_keys, 7) != "" ? element(local.tag_keys, 7) : "",
+      element(local.tag_values, 7) != "" ? element(local.tag_values, 7) : "",
+      "true"
+    )
+  }"
+
+  list8 = "${list(
+      element(local.tag_keys, 8) != "" ? element(local.tag_keys, 8) : "",
+      element(local.tag_values, 8) != "" ? element(local.tag_values, 8) : "",
+      "true"
+    )
+  }"
+
+  list9 = "${list(
+    element(local.tag_keys, 9) != "" ? element(local.tag_keys, 9) : "",
+    element(local.tag_values, 9) != "" ? element(local.tag_values, 9) : "",
+    "true"
+  )
+  }"
+
+  # Construct list of dicts in required format by zipmapping the value lists with the standard key list
+  # Slicing to the length of the map of tags so we dont get blank or repeating tags
+  tags_asg_format = "${slice(list(
+      zipmap(
+        local.key_list,
+        local.list0
+      ) ,
+      zipmap(
+        local.key_list,
+        local.list1
+      ),
+      zipmap(
+        local.key_list,
+        local.list2
+      ),
+      zipmap(
+        local.key_list,
+        local.list3
+      ),
+      zipmap(
+        local.key_list,
+        local.list4
+      ),
+      zipmap(
+        local.key_list,
+        local.list5
+      ),
+      zipmap(
+        local.key_list,
+        local.list6
+      ),
+      zipmap(
+        local.key_list,
+        local.list7
+      ),
+      zipmap(
+        local.key_list,
+        local.list8
+      ),
+      zipmap(
+        local.key_list,
+        local.list9
+      )
+    ), 0, length(local.tag_keys) - 1)
+  }"
+}

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "aws_autoscaling_group" "this" {
 
   tags = ["${concat(
       list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
-      var.tags
+      var.tags,
+      local.tags_asg_format
    )}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,3 +69,4 @@ output "this_autoscaling_group_health_check_type" {
 //  description = "List of Target Group ARNs that apply to this AutoScaling Group"
 //  value       = "${aws_autoscaling_group.this.target_group_arns}"
 //}
+

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,12 @@ variable "tags" {
   default     = []
 }
 
+variable "tags_as_map" {
+  description = "A map of tags and values in the same format as other resources accept.  This will be zipmapped into the non-standard format that the aws_autoscaling_group requires."
+  type        = "map"
+  default     = {}
+}
+
 variable "placement_group" {
   description = "The name of the placement group into which you'll launch your instances, if any"
   default     = ""


### PR DESCRIPTION
added support for up to 10 custom tags in the same format as all other aws resources by using interpolation in local variables that split and rejoin in appropriate format.

This requires alot more code then it should, but due to Terraform being declarative and not having iterators on non-resource objects we inevitably need some repetition.  Would love to hear what you think about this addition.  Should not interfere with existing configurations but does allow for an additional variable that concats with the existing tags variable in main.tf.  Passes my local testing.