### PR TITLE
Enable spot_price on launch configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,8 @@ resource "aws_launch_configuration" "this" {
   associate_public_ip_address = "${var.associate_public_ip_address}"
   user_data                   = "${var.user_data}"
   enable_monitoring           = "${var.enable_monitoring}"
-  placement_tenancy           = "${var.placement_tenancy}"
+  spot_price                  = "${var.spot_price}"
+  placement_tenancy           = "${var.spot_price == "" ? var.placement_tenancy : ""}"
   ebs_optimized               = "${var.ebs_optimized}"
   ebs_block_device            = "${var.ebs_block_device}"
   ephemeral_block_device      = "${var.ephemeral_block_device}"
@@ -22,8 +23,6 @@ resource "aws_launch_configuration" "this" {
   lifecycle {
     create_before_destroy = true
   }
-
-  # spot_price                  = "${var.spot_price}"  // placement_tenancy does not work with spot_price
 }
 
 ####################

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "ephemeral_block_device" {
 
 variable "spot_price" {
   description = "The price to use for reserving spot instances"
-  default     = 0
+  default     = ""
 }
 
 variable "placement_tenancy" {


### PR DESCRIPTION
`spot_price` does not work with `placement_tenancy`.

But if you set `spot_price` or `placement_tenancy` individually, it do work.

By specifying `spot_price` to `""` by default, it act as no spot price so
you can set `placement_tenancy` to `dedicated`.

Using the ternary for `placement_tenancy`, it allows to specify `spot_price`
and leave `placement_tenancy` to the default value.