### PR TITLE
Added conditional for initial_lifecycle_hook parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | placement_group | The name of the placement group into which you'll launch your instances, if any | string | `` | no |
 | placement_tenancy | The tenancy of the instance. Valid values are 'default' or 'dedicated' | string | `default` | no |
 | protect_from_scale_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events. | string | `false` | no |
+| recreate_asg_when_lc_changes | Whether to recreate an autoscaling group when launch configuration changes | string | `false` | no |
 | root_block_device | Customize details about the root block device of the instance | list | `<list>` | no |
 | security_groups | A list of security group IDs to assign to the launch configuration | list | - | yes |
 | spot_price | The price to use for reserving spot instances | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ launch_configuration = "existing-launch-configuration"
 create_asg = false
 ```
 
+1. To create ASG with initial lifecycle hook
+```hcl
+create_asg = false
+create_asg_with_initial_lifecycle_hook = true
+
+initial_lifecycle_hook_name                  = "NameOfLifeCycleHook"
+initial_lifecycle_hook_transition            = "autoscaling:EC2_INSTANCE_TERMINATING"
+initial_lifecycle_hook_notification_metadata =<<EOF
+{
+  "foo": "bar"
+}
+EOF
+```
 1. To disable creation of both resources (LC and ASG) you can specify both arguments `create_lc = false` and `create_asg = false`. Sometimes you need to use this way to create resources in modules conditionally but Terraform does not allow to use `count` inside `module` block.
 
 ## Tags
@@ -115,6 +128,13 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | health_check_type | Controls how health checking is done. Values are - EC2 and ELB | string | - | yes |
 | iam_instance_profile | The IAM instance profile to associate with launched instances | string | `` | no |
 | image_id | The EC2 image ID to launch | string | - | yes |
+| initial_lifecycle_hook_name | Name of the inital lifecycle hook | string | - | yes
+| initial_lifecycle_hook_transition | Lifecycle hook transition type | string | - | yes
+| initial_lifecycle_hook_notification_metadata | Metadata sent from the lifecycle hook | string | - | no
+| initial_lifecycle_hook_heartbeat_time | Time in seconds before the lifecycle hook times out | string | `60` | no
+| initial_lifecycle_hook_notification_target_arn | Arn of the notification target can be SQS queue or SNS topic | string | - | no 
+| initial_lifecycle_hook_role_arn | The ARN of the IAM role that allows ASG to publish to specified target ARN | string | - | no
+| initial_lifecycle_hook_default_result | Defines the Action the ASG should take when the lifecycle hook times out or fails | string | `continue` | no
 | instance_type | The size of instance to launch | string | - | yes |
 | key_name | The key name that should be used for the instance | string | `` | no |
 | launch_configuration | The name of the launch configuration to use (if it is created outside of this module) | string | `` | no |

--- a/examples/asg_ec2/main.tf
+++ b/examples/asg_ec2/main.tf
@@ -59,10 +59,11 @@ module "example" {
   # create_lc = false # disables creation of launch configuration
   lc_name = "example-lc"
 
-  image_id                    = "${data.aws_ami.amazon_linux.id}"
-  instance_type               = "t2.micro"
-  security_groups             = ["${data.aws_security_group.default.id}"]
-  associate_public_ip_address = true
+  image_id                     = "${data.aws_ami.amazon_linux.id}"
+  instance_type                = "t2.micro"
+  security_groups              = ["${data.aws_security_group.default.id}"]
+  associate_public_ip_address  = true
+  recreate_asg_when_lc_changes = true
 
   ebs_block_device = [
     {

--- a/examples/asg_inital_lifecycle_hook/README.md
+++ b/examples/asg_inital_lifecycle_hook/README.md
@@ -1,0 +1,28 @@
+# Auto Scaling Group without ELB example
+
+Configuration in this directory creates Launch Configuration and Auto Scaling Group.
+
+Data sources are used to discover existing VPC resources (VPC, subnet and security group) as well as AMI details.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this_autoscaling_group_id | The autoscaling group id |
+| this_launch_configuration_id | The ID of the launch configuration |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_inital_lifecycle_hook/main.tf
+++ b/examples/asg_inital_lifecycle_hook/main.tf
@@ -1,0 +1,123 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+##############################################################
+# Data sources to get VPC, subnets and security group details
+##############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+  name   = "default"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  filter {
+    name = "name"
+
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+
+  filter {
+    name = "owner-alias"
+
+    values = [
+      "amazon",
+    ]
+  }
+}
+
+######
+# Launch configuration and autoscaling group
+######
+module "example" {
+  source = "../../"
+
+  name = "example-with-ec2-lifecycle-hook"
+
+  create_asg = false
+  create_asg_with_initial_lifecycle_hook = true
+
+  initial_lifecycle_hook_name                  = "ExampleLifeCycleHook"
+  initial_lifecycle_hook_transition            = "autoscaling:EC2_INSTANCE_TERMINATING"
+  # This could be a rendered data resource
+  initial_lifecycle_hook_notification_metadata =<<EOF
+{
+  "foo": "bar"
+}
+EOF
+
+  # Launch configuration
+  #
+  # launch_configuration = "my-existing-launch-configuration" # Use the existing launch configuration
+  # create_lc = false # disables creation of launch configuration
+  lc_name = "example-lc"
+
+  image_id                     = "${data.aws_ami.amazon_linux.id}"
+  instance_type                = "t2.micro"
+  security_groups              = ["${data.aws_security_group.default.id}"]
+  associate_public_ip_address  = true
+  recreate_asg_when_lc_changes = true
+
+  ebs_block_device = [
+    {
+      device_name           = "/dev/xvdz"
+      volume_type           = "gp2"
+      volume_size           = "50"
+      delete_on_termination = true
+    },
+  ]
+
+  root_block_device = [
+    {
+      volume_size           = "50"
+      volume_type           = "gp2"
+      delete_on_termination = true
+    },
+  ]
+
+  # Auto scaling group
+  asg_name                  = "example-asg"
+  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  health_check_type         = "EC2"
+  min_size                  = 0
+  max_size                  = 1
+  desired_capacity          = 0
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Environment"
+      value               = "dev"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Project"
+      value               = "megasecret"
+      propagate_at_launch = true
+    },
+  ]
+
+  tags_as_map = {
+    extra_tag1 = "extra_value1"
+    extra_tag2 = "extra_value2"
+  }
+}

--- a/examples/asg_inital_lifecycle_hook/outputs.tf
+++ b/examples/asg_inital_lifecycle_hook/outputs.tf
@@ -1,0 +1,9 @@
+output "this_launch_configuration_id" {
+  description = "The ID of the launch configuration"
+  value       = "${module.example.this_launch_configuration_id}"
+}
+
+output "this_autoscaling_group_id" {
+  description = "The autoscaling group id"
+  value       = "${module.example.this_autoscaling_group_id}"
+}

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,57 @@ resource "aws_autoscaling_group" "this" {
   }
 }
 
+################################################
+# Autoscaling group with initial lifecycle hook
+################################################
+resource "aws_autoscaling_group" "with_initial_lifecycle_hook" {
+  count = "${var.create_asg_with_initial_lifecycle_hook}"
+
+  name_prefix          = "${join("-", compact(list(coalesce(var.asg_name, var.name), var.recreate_asg_when_lc_changes ? element(concat(random_pet.asg_name.*.id, list("")), 0) : "")))}-"
+  launch_configuration = "${var.create_lc ? element(aws_launch_configuration.this.*.name, 0) : var.launch_configuration}"
+  vpc_zone_identifier  = ["${var.vpc_zone_identifier}"]
+  max_size             = "${var.max_size}"
+  min_size             = "${var.min_size}"
+  desired_capacity     = "${var.desired_capacity}"
+
+  load_balancers            = ["${var.load_balancers}"]
+  health_check_grace_period = "${var.health_check_grace_period}"
+  health_check_type         = "${var.health_check_type}"
+
+  min_elb_capacity          = "${var.min_elb_capacity}"
+  wait_for_elb_capacity     = "${var.wait_for_elb_capacity}"
+  target_group_arns         = ["${var.target_group_arns}"]
+  default_cooldown          = "${var.default_cooldown}"
+  force_delete              = "${var.force_delete}"
+  termination_policies      = "${var.termination_policies}"
+  suspended_processes       = "${var.suspended_processes}"
+  placement_group           = "${var.placement_group}"
+  enabled_metrics           = ["${var.enabled_metrics}"]
+  metrics_granularity       = "${var.metrics_granularity}"
+  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+  protect_from_scale_in     = "${var.protect_from_scale_in}"
+
+  initial_lifecycle_hook {
+    name                    = "${var.initial_lifecycle_hook_name}"
+    lifecycle_transition    = "${var.initial_lifecycle_hook_transition}"
+    notification_metadata   = "${var.initial_lifecycle_hook_notification_metadata}"
+    heartbeat_timeout       = "${var.initial_lifecycle_hook_heartbeat_time}"
+    notification_target_arn = "${var.initial_lifecycle_hook_notification_target_arn}"
+    role_arn                = "${var.initial_lifecycle_hook_role_arn}"
+    default_result          = "${var.initial_lifecycle_hook_default_result}"
+  }
+
+  tags = ["${concat(
+      list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
+      var.tags,
+      local.tags_asg_format
+   )}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "random_pet" "asg_name" {
   count = "${var.recreate_asg_when_lc_changes ? 1 : 0}"
 

--- a/main.tf
+++ b/main.tf
@@ -60,4 +60,8 @@ resource "aws_autoscaling_group" "this" {
       var.tags,
       local.tags_asg_format
    )}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,46 @@ variable "create_asg" {
   default     = true
 }
 
+variable "create_asg_with_initial_lifecycle_hook" {
+  description = "Create an ASG with intial"
+  default     = false
+}
+
+variable "initial_lifecycle_hook_name" {
+  description = "Initial lifecycle hook name required parameter"
+  default     = ""
+}
+
+variable "initial_lifecycle_hook_transition" {
+  description = "Initial Lifecycle hook transtion type"
+  default     = ""
+}
+
+variable "initial_lifecycle_hook_default_result" {
+  description = "Defines the default action the autoscaler takes when the lifecyle hook timesout"
+  default     = "CONTINUE"
+}
+
+variable "initial_lifecycle_hook_notification_metadata" {
+  description = "Metadata for the lifecycle notification event"
+  default     = ""
+}
+
+variable "initial_lifecycle_hook_heartbeat_time" {
+  description = "Lifecyle action timer"
+  default     = "60"
+}
+
+variable "initial_lifecycle_hook_notification_target_arn" {
+  description = "SNS target arn to allow notifications from autoscaling group"
+  default     = ""
+}
+
+variable "initial_lifecycle_hook_role_arn" {
+  description = "AWS iam role to grant access to notification target"
+  default     = ""
+}
+
 variable "recreate_asg_when_lc_changes" {
   description = "Whether to recreate an autoscaling group when launch configuration changes"
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "create_asg" {
   default     = true
 }
 
+variable "recreate_asg_when_lc_changes" {
+  description = "Whether to recreate an autoscaling group when launch configuration changes"
+  default     = false
+}
+
 variable "name" {
   description = "Creates a unique name beginning with the specified prefix"
 }


### PR DESCRIPTION
I proposed adding the terraform resource `aws_autoscaling_lifecycle_hook` into this module. @antonbabenko suggested creating a submodule to allow this, this is still outstanding. However this PR allows you to create an `aws_autoscaling_group` with the parameter `initial_lifecycle_hook`. The reason behind this is that if you use the `aws_autoscaling_lifecycle_hook` resource when issuing a terraform destroy the lifecycle hook is removed from the autoscaling group before any lifecycle transition occurs. This is an issue when creating events based on instance termination.

In my usecase we are using the servicenaming API to register instances into Route53, the lifecycle hook is used to remove Route53 records if / when instances are terminated. So issuing a terraform destroy, terraform removes the instance from the ASG prior to any lifecycle transition. If you use the `initial_lifecycle_hook` parameter within the autoscaling group resource, the ASG transitions as expected and waits for the terminate lifecycle action to complete before destroying the ASG.

I had to create a separate resource because the `initial_lifecycle_hook` as some required parameters. I tried to use a similar pattern to how the tags work, but due to the current hit & miss with maps and lists within the HCL language it didn't work.

I've updated the README with the new variables and also created an additional example.