### PR TITLE
Var defaults when create_lc is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | health_check_grace_period | Time (in seconds) after instance comes into service before checking health | string | `300` | no |
 | health_check_type | Controls how health checking is done. Values are - EC2 and ELB | string | - | yes |
 | iam_instance_profile | The IAM instance profile to associate with launched instances | string | `` | no |
-| image_id | The EC2 image ID to launch | string | - | yes |
-| instance_type | The size of instance to launch | string | - | yes |
+| image_id | The EC2 image ID to launch | string | `` | no |
+| instance_type | The size of instance to launch | string | `` | no |
 | key_name | The key name that should be used for the instance | string | `` | no |
 | launch_configuration | The name of the launch configuration to use (if it is created outside of this module) | string | `` | no |
 | lc_name | Creates a unique name for launch configuration beginning with the specified prefix | string | `` | no |
@@ -130,7 +130,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | protect_from_scale_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events. | string | `false` | no |
 | recreate_asg_when_lc_changes | Whether to recreate an autoscaling group when launch configuration changes | string | `false` | no |
 | root_block_device | Customize details about the root block device of the instance | list | `<list>` | no |
-| security_groups | A list of security group IDs to assign to the launch configuration | list | - | yes |
+| security_groups | A list of security group IDs to assign to the launch configuration | list | `<list>` | no |
 | spot_price | The price to use for reserving spot instances | string | `` | no |
 | suspended_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | string | `<list>` | no |
 | tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | string | `<list>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -35,10 +35,12 @@ variable "launch_configuration" {
 # Launch configuration
 variable "image_id" {
   description = "The EC2 image ID to launch"
+  default     = ""
 }
 
 variable "instance_type" {
   description = "The size of instance to launch"
+  default     = ""
 }
 
 variable "iam_instance_profile" {
@@ -54,6 +56,7 @@ variable "key_name" {
 variable "security_groups" {
   description = "A list of security group IDs to assign to the launch configuration"
   type        = "list"
+  default     = []
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
When create_lc is false the module still currently requires image_id, instance_type and security_groups to be provided even though these are unused anywhere else by the module.