### PR TITLE
Scaling notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ create_lc = false
 launch_configuration = "existing-launch-configuration"
 ```
 
-1. To create LC, but not ASG. Outputs may produce errors.
+2. To create LC, but not ASG. Outputs may produce errors.
 ```hcl
 create_asg = false
 ```
 
-1. To disable creation of both resources (LC and ASG) you can specify both arguments `create_lc = false` and `create_asg = false`. Sometimes you need to use this way to create resources in modules conditionally but Terraform does not allow to use `count` inside `module` block.
+3. To disable creation of both resources (LC and ASG) you can specify both arguments `create_lc = false` and `create_asg = false`. Sometimes you need to use this way to create resources in modules conditionally but Terraform does not allow to use `count` inside `module` block.
 
 ## Tags
 
@@ -93,6 +93,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 * [Auto Scaling Group without ELB](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/tree/master/examples/asg_ec2)
 * [Auto Scaling Group with ELB](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/tree/master/examples/asg_elb)
 * [Auto Scaling Group with external Launch Configuration](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/tree/master/examples/asg_ec2_external_launch_configuration)
+* [Auto Scaling Group with Notification SNS](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/tree/master/examples/asg_ec2_sns_notification)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 |------|-------------|:----:|:-----:|:-----:|
 | asg_name | Creates a unique name for autoscaling group beginning with the specified prefix | string | `` | no |
 | associate_public_ip_address | Associate a public ip address with an instance in a VPC | string | `false` | no |
+| computed_scaling_notifications | A list of maps containing information regarding SNS notification to set up for scaling event of the autoscaling group - this accepts reference to other resources | list | `<list>` | no |
 | create_asg | Whether to create autoscaling group | string | `true` | no |
 | create_lc | Whether to create launch configuration | string | `true` | no |
 | default_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | string | `300` | no |
@@ -127,11 +128,13 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | min_elb_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | string | `0` | no |
 | min_size | The minimum size of the auto scale group | string | - | yes |
 | name | Creates a unique name beginning with the specified prefix | string | - | yes |
+| number_of_computed_scaling_notifications | Number of elements of computed_scaling_notifications that you would like to set up | string | `0` | no |
 | placement_group | The name of the placement group into which you'll launch your instances, if any | string | `` | no |
 | placement_tenancy | The tenancy of the instance. Valid values are 'default' or 'dedicated' | string | `default` | no |
 | protect_from_scale_in | Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events. | string | `false` | no |
 | recreate_asg_when_lc_changes | Whether to recreate an autoscaling group when launch configuration changes | string | `false` | no |
 | root_block_device | Customize details about the root block device of the instance | list | `<list>` | no |
+| scaling_notifications | A list of maps containing information regarding SNS notification to set up for scaling event of the autoscaling group | list | `<list>` | no |
 | security_groups | A list of security group IDs to assign to the launch configuration | list | `<list>` | no |
 | spot_price | The price to use for reserving spot instances | string | `` | no |
 | suspended_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | string | `<list>` | no |

--- a/examples/asg_ec2_sns_notification/README.md
+++ b/examples/asg_ec2_sns_notification/README.md
@@ -1,0 +1,36 @@
+# Auto Scaling Group with SNS Notifications Example
+
+Configuration in this directory creates Launch Configuration, Auto Scaling Group, Elastic Load Balancer, places Auto Scaling EC2 instances under ELB as well as SNS Topics which is used to notify on scaling events, another SNS topics with Slack integration is created. The Auto Scaling Group is connected to these topics via Scaling Notification mechanism.
+
+Data sources are used to discover existing VPC resources (VPC, subnet and security group) as well as AMI details.
+
+## Ordering of applying and the use of `count`
+
+Due to [the complication of using `count`](https://github.com/hashicorp/terraform/issues/12570) and [the upcoming plan to fix it](https://github.com/hashicorp/terraform/issues/4149), the parameter `scaling_notification` assumes that the resources that you are referring to form it (ie. the SNS topics) must have already been created.
+
+That means within this example (as when as when you use the `scaling_notification` variable, you will have to make sure that the SNS Topics is created before you apply this module (I think that's reasonable). The `Usage` section below shows how you can use the flag `-target` to ensure such behaviour.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply -target module.sns_topic -target module.slack_notification
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this_autoscaling_group_id | Autoscaling group |
+| this_elb_dns_name | ELB DNS name |
+| this_launch_configuration_id | Launch configuration |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_ec2_sns_notification/README.md
+++ b/examples/asg_ec2_sns_notification/README.md
@@ -4,12 +4,6 @@ Configuration in this directory creates Launch Configuration, Auto Scaling Group
 
 Data sources are used to discover existing VPC resources (VPC, subnet and security group) as well as AMI details.
 
-## Ordering of applying and the use of `count`
-
-Due to [the complication of using `count`](https://github.com/hashicorp/terraform/issues/12570) and [the upcoming plan to fix it](https://github.com/hashicorp/terraform/issues/4149), the parameter `scaling_notification` assumes that the resources that you are referring to form it (ie. the SNS topics) must have already been created.
-
-That means within this example (as when as when you use the `scaling_notification` variable, you will have to make sure that the SNS Topics is created before you apply this module (I think that's reasonable). The `Usage` section below shows how you can use the flag `-target` to ensure such behaviour.
-
 ## Usage
 
 To run this example you need to execute:
@@ -17,11 +11,16 @@ To run this example you need to execute:
 ```bash
 $ terraform init
 $ terraform plan
-$ terraform apply -target module.sns_topic -target module.slack_notification
 $ terraform apply
 ```
 
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+## `notification_scalings` - Ordering of applying and the use of `count`
+
+Due to [the complication of using `count`](https://github.com/hashicorp/terraform/issues/12570) and [the upcoming plan to fix it](https://github.com/hashicorp/terraform/issues/4149), the parameter `scaling_notification` assumes that the resources that you are referring to form it (ie. the SNS topics) must have already been created.
+
+That means within this example (as when as when you use the `scaling_notification` variable, you will have to make sure that the SNS Topics is created before you apply this module (I think that's reasonable). The `Usage` section below shows how you can use the flag `-target` to ensure such behaviour.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
@@ -29,8 +28,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_autoscaling_group_id | Autoscaling group |
-| this_elb_dns_name | ELB DNS name |
-| this_launch_configuration_id | Launch configuration |
+| this_autoscaling_group_id | The autoscaling group id |
+| this_elb_dns_name | DNS Name of the ELB |
+| this_launch_configuration_id | The ID of the launch configuration |
+| this_pure_sns_topic | ARN of the SNS topic you can subscribe to receive notifications |
+| this_slack_sns_topic | ARN of the SNS topic you can subscribe to receive notifications |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_ec2_sns_notification/main.tf
+++ b/examples/asg_ec2_sns_notification/main.tf
@@ -95,7 +95,23 @@ module "example_asg" {
     },
   ]
 
-  scaling_notification = [
+  # Without passing an additional variable - You will have to use -target for this
+  # scaling_notifications = [
+  # {
+  # topic_arn = "${module.sns_topic.this_sns_topic_arn}"
+  # },
+  # {
+  # topic_arn = "${module.notify_slack.this_slack_topic_arn}"
+  #
+  # notifications = "${join(",", list(
+  # "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+  # "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+  # ))}"
+  # },
+  # ]
+
+  # Require additional variable
+  computed_scaling_notifications = [
     {
       topic_arn = "${module.sns_topic.this_sns_topic_arn}"
     },
@@ -103,11 +119,12 @@ module "example_asg" {
       topic_arn = "${module.notify_slack.this_slack_topic_arn}"
 
       notifications = "${join(",", list(
-        "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-        "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
-      ))}"
+  "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+  "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+  ))}"
     },
   ]
+  number_of_computed_scaling_notifications = 2
 }
 
 ######

--- a/examples/asg_ec2_sns_notification/main.tf
+++ b/examples/asg_ec2_sns_notification/main.tf
@@ -1,0 +1,167 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+##############################################################
+# Data sources to get VPC, subnets and security group details
+##############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+  name   = "default"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  filter {
+    name = "name"
+
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+
+  filter {
+    name = "owner-alias"
+
+    values = [
+      "amazon",
+    ]
+  }
+}
+
+######
+# Launch configuration and autoscaling group
+######
+module "example_asg" {
+  source = "../../"
+
+  name = "example-with-elb"
+
+  # Launch configuration
+  #
+  # launch_configuration = "my-existing-launch-configuration" # Use the existing launch configuration
+  # create_lc = false # disables creation of launch configuration
+  lc_name = "example-lc"
+
+  image_id        = "${data.aws_ami.amazon_linux.id}"
+  instance_type   = "t2.micro"
+  security_groups = ["${data.aws_security_group.default.id}"]
+  load_balancers  = ["${module.elb.this_elb_id}"]
+
+  ebs_block_device = [
+    {
+      device_name           = "/dev/xvdz"
+      volume_type           = "gp2"
+      volume_size           = "10"
+      delete_on_termination = true
+    },
+  ]
+
+  root_block_device = [
+    {
+      volume_size = "50"
+      volume_type = "gp2"
+    },
+  ]
+
+  # Auto scaling group
+  asg_name                  = "example-asg"
+  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  health_check_type         = "EC2"
+  min_size                  = 0
+  max_size                  = 1
+  desired_capacity          = 0
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Environment"
+      value               = "dev"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Project"
+      value               = "megasecret"
+      propagate_at_launch = true
+    },
+  ]
+
+  scaling_notification = [
+    {
+      topic_arn = "${module.sns_topic.this_sns_topic_arn}"
+    },
+    {
+      topic_arn = "${module.notify_slack.this_slack_topic_arn}"
+
+      notifications = "${join(",", list(
+        "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+        "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+      ))}"
+    },
+  ]
+}
+
+######
+# ELB
+######
+module "elb" {
+  source = "terraform-aws-modules/elb/aws"
+
+  name = "elb-example"
+
+  subnets         = ["${data.aws_subnet_ids.all.ids}"]
+  security_groups = ["${data.aws_security_group.default.id}"]
+  internal        = false
+
+  listener = [
+    {
+      instance_port     = "80"
+      instance_protocol = "HTTP"
+      lb_port           = "80"
+      lb_protocol       = "HTTP"
+    },
+  ]
+
+  health_check = [
+    {
+      target              = "HTTP:80/"
+      interval            = 30
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+      timeout             = 5
+    },
+  ]
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+######
+# SNS
+######
+module "sns_topic" {
+  source = "terraform-aws-modules/sns/aws"
+
+  sns_topic_name = "scaling-events"
+}
+
+module "notify_slack" {
+  source = "terraform-aws-modules/notify-slack/aws"
+
+  sns_topic_name = "scaling-errors"
+
+  slack_webhook_url = "https://hooks.slack.com/services/AAA/BBB/CCC"
+  slack_channel     = "aws-notification"
+  slack_username    = "reporter"
+}

--- a/examples/asg_ec2_sns_notification/main.tf
+++ b/examples/asg_ec2_sns_notification/main.tf
@@ -119,9 +119,9 @@ module "example_asg" {
       topic_arn = "${module.notify_slack.this_slack_topic_arn}"
 
       notifications = "${join(",", list(
-  "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-  "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
-  ))}"
+        "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+        "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+      ))}"
     },
   ]
   number_of_computed_scaling_notifications = 2

--- a/examples/asg_ec2_sns_notification/outputs.tf
+++ b/examples/asg_ec2_sns_notification/outputs.tf
@@ -1,0 +1,29 @@
+# Launch configuration
+output "this_launch_configuration_id" {
+  description = "The ID of the launch configuration"
+  value       = "${module.example_asg.this_launch_configuration_id}"
+}
+
+# Autoscaling group
+output "this_autoscaling_group_id" {
+  description = "The autoscaling group id"
+  value       = "${module.example_asg.this_autoscaling_group_id}"
+}
+
+# ELB DNS name
+output "this_elb_dns_name" {
+  description = "DNS Name of the ELB"
+  value       = "${module.elb.this_elb_dns_name}"
+}
+
+# Notification Topic - Pure SNS
+output "this_pure_sns_topic" {
+  description = "ARN of the SNS topic you can subscribe to receive notifications"
+  value       = "${module.sns_topic.this_sns_topic_arn}"
+}
+
+# Notification Topic - Slack
+output "this_slack_sns_topic" {
+  description = "ARN of the SNS topic you can subscribe to receive notifications"
+  value       = "${module.notify_slack.this_slack_topic_arn}"
+}

--- a/examples/asg_elb/README.md
+++ b/examples/asg_elb/README.md
@@ -22,8 +22,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_autoscaling_group_id | Autoscaling group |
-| this_elb_dns_name | ELB DNS name |
-| this_launch_configuration_id | Launch configuration |
+| this_autoscaling_group_id | The autoscaling group id |
+| this_elb_dns_name | DNS Name of the ELB |
+| this_launch_configuration_id | The ID of the launch configuration |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,13 @@
 locals {
   tags_asg_format = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
+
+  all_notification_types = "${join(",", list(
+    "autoscaling:EC2_INSTANCE_LAUNCH",
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+    "autoscaling:EC2_INSTANCE_TERMINATE",
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+    "autoscaling:TEST_NOTIFICATION",
+  ))}"
 }
 
 resource "null_resource" "tags_as_list_of_maps" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,9 @@
 locals {
   tags_asg_format = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 
+  all_notifications  = "${concat(var.scaling_notifications, var.computed_scaling_notifications)}"
+  notification_count = "${length(var.scaling_notifications) + var.number_of_computed_scaling_notifications}"
+
   all_notification_types = "${join(",", list(
     "autoscaling:EC2_INSTANCE_LAUNCH",
     "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",

--- a/main.tf
+++ b/main.tf
@@ -77,3 +77,13 @@ resource "random_pet" "asg_name" {
     lc_name = "${var.create_lc ? element(concat(aws_launch_configuration.this.*.name, list("")), 0) : var.launch_configuration}"
   }
 }
+
+#####################################
+# Scaling notification to SNS Topics
+#####################################
+resource "aws_autoscaling_notification" "this" {
+  count         = "${var.create_asg? length(var.scaling_notification) : 0}"
+  group_names   = ["${element(concat(aws_autoscaling_group.this.*.name, list("")), 0)}"]
+  notifications = ["${split(",", lookup(var.scaling_notification[count.index], "notifications", local.all_notification_types))}"]
+  topic_arn     = "${lookup(var.scaling_notification[count.index], "topic_arn")}"
+}

--- a/main.tf
+++ b/main.tf
@@ -82,8 +82,8 @@ resource "random_pet" "asg_name" {
 # Scaling notification to SNS Topics
 #####################################
 resource "aws_autoscaling_notification" "this" {
-  count         = "${var.create_asg? length(var.scaling_notification) : 0}"
+  count         = "${var.create_asg? local.notification_count : 0}"
   group_names   = ["${element(concat(aws_autoscaling_group.this.*.name, list("")), 0)}"]
-  notifications = ["${split(",", lookup(var.scaling_notification[count.index], "notifications", local.all_notification_types))}"]
-  topic_arn     = "${lookup(var.scaling_notification[count.index], "topic_arn")}"
+  notifications = ["${split(",", lookup(local.all_notifications[count.index], "notifications", local.all_notification_types))}"]
+  topic_arn     = "${lookup(local.all_notifications[count.index], "topic_arn")}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -222,8 +222,19 @@ variable "protect_from_scale_in" {
   default     = false
 }
 
-variable "scaling_notification" {
+variable "scaling_notifications" {
   type        = "list"
   default     = []
   description = "A list of maps containing information regarding SNS notification to set up for scaling event of the autoscaling group"
+}
+
+variable "computed_scaling_notifications" {
+  type        = "list"
+  default     = []
+  description = "A list of maps containing information regarding SNS notification to set up for scaling event of the autoscaling group - this accepts reference to other resources"
+}
+
+variable "number_of_computed_scaling_notifications" {
+  default     = 0
+  description = "Number of elements of computed_scaling_notifications that you would like to set up"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,9 @@ variable "protect_from_scale_in" {
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events."
   default     = false
 }
+
+variable "scaling_notification" {
+  type        = "list"
+  default     = []
+  description = "A list of maps containing information regarding SNS notification to set up for scaling event of the autoscaling group"
+}


### PR DESCRIPTION
Support setting up scaling notification for the ASG to connect it to SNS Topics.

The new parameters (`computed_scaling_notifications`, `number_of_ computed_scaling_notifications` and `scaling_notifications`) took a very similar approach to the one in the [security-group module](https://github.com/terraform-aws-modules/terraform-aws-security-group).

I added an example to demonstrate the idea and how to use it (using pure SNS topic and SNS Topic with Slack integration). I hope that will come in handy.

P/S: I found that the numbering in section `Conditional creation` was incorrect so I took the chance to change that as well.