### PR TITLE
Ignore desired_capacity changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "aws_autoscaling_group" "this" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["desired_capacity"]
   }
 }
 


### PR DESCRIPTION
That way autoscale groups can scale without terraform overriding it,

The only way desired_capacity would be affected is if something else caused the ASG to be re-created, or the current desired_capacity ended up outside the barrier of min and max capacity. Since AWS will automatically adjust the desired to be within that range.