### PR TITLE
fix for terraform-aws-modules/terraform-aws-autoscaling/issues/57

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_launch_configuration" "this" {
   key_name                    = "${var.key_name}"
   security_groups             = ["${var.security_groups}"]
   associate_public_ip_address = "${var.associate_public_ip_address}"
-  user_data                   = "${var.user_data}"
+  user_data_base64            = "${var.user_data_base64}"
   enable_monitoring           = "${var.enable_monitoring}"
   spot_price                  = "${var.spot_price}"
   placement_tenancy           = "${var.spot_price == "" ? var.placement_tenancy : ""}"

--- a/variables.tf
+++ b/variables.tf
@@ -104,8 +104,8 @@ variable "associate_public_ip_address" {
   default     = false
 }
 
-variable "user_data" {
-  description = "The user data to provide when launching the instance"
+variable "user_data_base64" {
+  description = "Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string."
   default     = " "
 }
 


### PR DESCRIPTION
Unfortunately declaring them both raises an Error: `[...] "user_data": conflicts with user_data_base64`, so it's either one or another, but as described in the docs:
> [user_data_base64](https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#user_data_base64) - (Optional) Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption.

the latter sounds to be much more universal, so I'd say user_data_64 should replace user_data here.