### PR TITLE
Always provide an integer to the count parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Launch configuration
 #######################
 resource "aws_launch_configuration" "this" {
-  count = "${var.create_lc}"
+  count = "${var.create_lc ? 1 : 0}"
 
   name_prefix                 = "${coalesce(var.lc_name, var.name)}-"
   image_id                    = "${var.image_id}"


### PR DESCRIPTION
If `create_lc` is set to the string "true" or "false", TF fails with
this error :
```
  * module.test.aws_launch_configuration.this: cannot parse "false" as an integer
  * module.test.aws_launch_configuration.this: cannot parse "true" as an integer
```