### PR TITLE
Add service linked role support for Terraform 11 (Issue 63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | recreate\_asg\_when\_lc\_changes | Whether to recreate an autoscaling group when launch configuration changes | string | `"false"` | no |
 | root\_block\_device | Customize details about the root block device of the instance | list | `<list>` | no |
 | security\_groups | A list of security group IDs to assign to the launch configuration | list | `<list>` | no |
+| service\_linked\_role\_arn | The ARN of the service-linked role that the ASG will use to call other AWS services | string | `""` | no |
 | spot\_price | The price to use for reserving spot instances | string | `""` | no |
 | suspended\_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | list | `<list>` | no |
 | tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | list | `<list>` | no |
@@ -182,6 +183,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | this\_autoscaling\_group\_max\_size | The maximum size of the autoscale group |
 | this\_autoscaling\_group\_min\_size | The minimum size of the autoscale group |
 | this\_autoscaling\_group\_name | The autoscaling group name |
+| this\_autoscaling\_service\_linked\_role\_arn | The arn of the service linked role |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
 | this\_launch\_configuration\_name | The name of the launch configuration |
 

--- a/examples/asg_ec2/main.tf
+++ b/examples/asg_ec2/main.tf
@@ -27,6 +27,7 @@ data "aws_security_group" "default" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name = "name"

--- a/examples/asg_ec2_external_launch_configuration/main.tf
+++ b/examples/asg_ec2_external_launch_configuration/main.tf
@@ -22,6 +22,7 @@ data "aws_subnet_ids" "all" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name = "name"

--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -20,6 +20,7 @@ data "aws_security_group" "default" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name = "name"
@@ -101,6 +102,7 @@ module "example_asg" {
 ######
 module "elb" {
   source = "terraform-aws-modules/elb/aws"
+  version = ">= 1.0.0, < 2.0.0"
 
   name = "elb-example"
 

--- a/examples/asg_inital_lifecycle_hook/main.tf
+++ b/examples/asg_inital_lifecycle_hook/main.tf
@@ -27,6 +27,7 @@ data "aws_security_group" "default" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name = "name"

--- a/examples/asg_service_linked_role/README.md
+++ b/examples/asg_service_linked_role/README.md
@@ -1,0 +1,42 @@
+# Auto Scaling Group with a custom service linked role
+
+Configuration in this directory creates Launch Configuration and Auto Scaling Group 
+with a customized service linked role. This is normally leveraged so that the ASG
+can use encrypted AMIs.
+
+Data sources are used to discover existing VPC resources (VPC, subnet and security group) as well as AMI details.
+
+NOTE:
+
+ - Creating the service-linked role within the same terraform run might fail with the 
+   following error, most likely due to the IAM syncing in the background. Re-running terraform apply
+   again will work.
+
+Error: Error applying plan:
+
+1 error occurred:
+	* module.example.aws_autoscaling_group.this: 1 error occurred:
+	* aws_autoscaling_group.this: Error creating AutoScaling Group: ValidationError: ARN specified for Service-Linked Role does not exist.
+	status code: 400, request id: f127baea-a76c-11e9-8ad4-dd6bbb197602
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this\_autoscaling\_group\_id | The autoscaling group id |
+| this\_launch\_configuration\_id | The ID of the launch configuration |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_service_linked_role/README.md
+++ b/examples/asg_service_linked_role/README.md
@@ -6,18 +6,22 @@ can use encrypted AMIs.
 
 Data sources are used to discover existing VPC resources (VPC, subnet and security group) as well as AMI details.
 
-NOTE:
+NOTES:
 
+ - We ignore the custom_suffix on the service_linked_role definition otherwise Terraform will
+   recreate it on every run.
  - Creating the service-linked role within the same terraform run might fail with the 
    following error, most likely due to the IAM syncing in the background. Re-running terraform apply
    again will work.
 
+```
 Error: Error applying plan:
 
 1 error occurred:
 	* module.example.aws_autoscaling_group.this: 1 error occurred:
 	* aws_autoscaling_group.this: Error creating AutoScaling Group: ValidationError: ARN specified for Service-Linked Role does not exist.
 	status code: 400, request id: f127baea-a76c-11e9-8ad4-dd6bbb197602
+```
 
 ## Usage
 
@@ -38,5 +42,6 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|-------------|
 | this\_autoscaling\_group\_id | The autoscaling group id |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
+| this\_service\_linked\_role\_arn | The arn of the custom service linked role |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_service_linked_role/main.tf
+++ b/examples/asg_service_linked_role/main.tf
@@ -51,6 +51,9 @@ resource "aws_iam_service_linked_role" "autoscaling_service_linked_role" {
   description = "A service linked role for autoscaling groups"
   custom_suffix = "TEST"
 
+  # Ignore the custom_suffix, otherwise Terraform will recreate
+  # this resource on every run
+  # https://www.terraform.io/docs/providers/aws/r/iam_service_linked_role.html
   lifecycle {
     ignore_changes = ["custom_suffix"]
   }

--- a/examples/asg_service_linked_role/main.tf
+++ b/examples/asg_service_linked_role/main.tf
@@ -1,0 +1,124 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+##############################################################
+# Data sources to get VPC, subnets and security group details
+##############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+  name   = "default"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+
+  filter {
+    name = "owner-alias"
+
+    values = [
+      "amazon",
+    ]
+  }
+}
+
+resource "aws_iam_service_linked_role" "autoscaling_service_linked_role" {
+  aws_service_name = "autoscaling.amazonaws.com"
+  description = "A service linked role for autoscaling groups"
+  custom_suffix = "TEST"
+
+  lifecycle {
+    ignore_changes = ["custom_suffix"]
+  }
+}
+
+
+######
+# Launch configuration and autoscaling group
+######
+module "example" {
+  source = "../../"
+
+  name = "example-with-ec2"
+
+  # Launch configuration
+  #
+  # launch_configuration = "my-existing-launch-configuration" # Use the existing launch configuration
+  # create_lc = false # disables creation of launch configuration
+  lc_name = "example-lc"
+
+  image_id                     = "${data.aws_ami.amazon_linux.id}"
+  instance_type                = "t2.micro"
+  security_groups              = ["${data.aws_security_group.default.id}"]
+  associate_public_ip_address  = true
+  recreate_asg_when_lc_changes = true
+  service_linked_role_arn      = "${aws_iam_service_linked_role.autoscaling_service_linked_role.arn}"
+
+  ebs_block_device = [
+    {
+      device_name           = "/dev/xvdz"
+      volume_type           = "gp2"
+      volume_size           = "50"
+      delete_on_termination = true
+    },
+  ]
+
+  root_block_device = [
+    {
+      volume_size           = "50"
+      volume_type           = "gp2"
+      delete_on_termination = true
+    },
+  ]
+
+  # Auto scaling group
+  asg_name                  = "example-asg"
+  vpc_zone_identifier       = ["${data.aws_subnet_ids.all.ids}"]
+  health_check_type         = "EC2"
+  min_size                  = 0
+  max_size                  = 1
+  desired_capacity          = 0
+  wait_for_capacity_timeout = 0
+
+  tags = [
+    {
+      key                 = "Environment"
+      value               = "dev"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Project"
+      value               = "megasecret"
+      propagate_at_launch = true
+    },
+  ]
+
+  tags_as_map = {
+    extra_tag1 = "extra_value1"
+    extra_tag2 = "extra_value2"
+  }
+}

--- a/examples/asg_service_linked_role/outputs.tf
+++ b/examples/asg_service_linked_role/outputs.tf
@@ -1,0 +1,14 @@
+output "this_launch_configuration_id" {
+  description = "The ID of the launch configuration"
+  value       = "${module.example.this_launch_configuration_id}"
+}
+
+output "this_autoscaling_group_id" {
+  description = "The autoscaling group id"
+  value       = "${module.example.this_autoscaling_group_id}"
+}
+
+output "this_service_linked_role_arn" {
+  description = "The arn of the custom service linked role"
+  value       = "${module.example.this_autoscaling_service_linked_role_arn}"
+}

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ resource "aws_autoscaling_group" "this" {
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
   protect_from_scale_in     = "${var.protect_from_scale_in}"
 
+  service_linked_role_arn   = "${var.service_linked_role_arn}"
+
   tags = ["${concat(
     list(map("key", "Name", "value", var.name, "propagate_at_launch", true)),
     var.tags,
@@ -95,6 +97,8 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
   metrics_granularity       = "${var.metrics_granularity}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
   protect_from_scale_in     = "${var.protect_from_scale_in}"
+
+  service_linked_role_arn   = "${var.service_linked_role_arn}"
 
   initial_lifecycle_hook {
     name                    = "${var.initial_lifecycle_hook_name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,6 +11,7 @@ locals {
   this_autoscaling_group_default_cooldown          = "${element(concat(coalescelist(aws_autoscaling_group.this.*.default_cooldown, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.default_cooldown), list("")), 0)}"
   this_autoscaling_group_health_check_grace_period = "${element(concat(coalescelist(aws_autoscaling_group.this.*.health_check_grace_period, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_grace_period), list("")), 0)}"
   this_autoscaling_group_health_check_type         = "${element(concat(coalescelist(aws_autoscaling_group.this.*.health_check_type, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_type), list("")), 0)}"
+  this_autoscaling_group_service_linked_role_arn   = "${element(concat(coalescelist(aws_autoscaling_group.this.*.service_linked_role_arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.service_linked_role_arn), list("")), 0)}"
 }
 
 output "this_launch_configuration_id" {
@@ -66,6 +67,11 @@ output "this_autoscaling_group_health_check_grace_period" {
 output "this_autoscaling_group_health_check_type" {
   description = "EC2 or ELB. Controls how health checking is done"
   value       = "${local.this_autoscaling_group_health_check_type}"
+}
+
+output "this_autoscaling_service_linked_role_arn" {
+  description = "The arn of the service linked role"
+  value       = "${local.this_autoscaling_group_service_linked_role_arn}"
 }
 
 //output "this_autoscaling_group_vpc_zone_identifier" {

--- a/variables.tf
+++ b/variables.tf
@@ -261,3 +261,8 @@ variable "protect_from_scale_in" {
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events."
   default     = false
 }
+
+variable "service_linked_role_arn" {
+  description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
+  default     = ""
+}


### PR DESCRIPTION
# Description

Add a new pass-through variable to allow an end-user to specify the service_linked_role_arn parameter to the underlining autoscaling group resource. This PR is to add that support to the Terraform 11 branch. 

Also fixed up the examples on the branch to work with terraform 11.
