### PR TITLE
Fixed example (health_check to map of strings)

### DIFF
--- a/examples/asg_elb/main.tf
+++ b/examples/asg_elb/main.tf
@@ -118,19 +118,16 @@ module "elb" {
     },
   ]
 
-  health_check = [
-    {
+  health_check = {
       target              = "HTTP:80/"
       interval            = 30
       healthy_threshold   = 2
       unhealthy_threshold = 2
       timeout             = 5
-    },
-  ]
+    }
 
   tags = {
     Owner       = "user"
     Environment = "dev"
   }
 }
-


### PR DESCRIPTION
# Description

```
The given value is not suitable for child module variable "health_check"
defined at .terraform/modules/elb/terraform-aws-modules-terraform-aws-elb-63ebc39/variables.tf:69,1-24: map of string required.
```