### PR TITLE
Adding option to use name variable along with name prefix variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@
 #######################
 resource "aws_launch_configuration" "this" {
   count = var.create_lc ? 1 : 0
-
-  name_prefix                 = "${coalesce(var.lc_name, var.name)}-"
+  name			      = var.name
+  name_prefix		      = var.name == null ? "${coalesce(var.lc_name, var.name)}-" : null
   image_id                    = var.image_id
   instance_type               = var.instance_type
   iam_instance_profile        = var.iam_instance_profile


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.
This PR will allow you to add name variable option to create launch config/autoscaling group. According to the documentation, we can use either of them. But according to the code, we can only use name-prefix. This PR will let you use either of these depending upon the null value of the other variable.