### PR TITLE
Adds service_linked_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | security\_groups | A list of security group IDs to assign to the launch configuration | list(string) | `[]` | no |
 | spot\_price | The price to use for reserving spot instances | string | `""` | no |
 | suspended\_processes | A list of processes to suspend for the AutoScaling Group. The allowed values are Launch, Terminate, HealthCheck, ReplaceUnhealthy, AZRebalance, AlarmNotification, ScheduledActions, AddToLoadBalancer. Note that if you suspend either the Launch or Terminate process types, it can prevent your autoscaling group from functioning properly. | list(string) | `[]` | no |
+| service\_linked\_role\_arn | The ARN of service linked role for Autoscaling Group to call other AWS services. | string | `""` | no |
 | tags | A list of tag blocks. Each element should have keys named key, value, and propagate_at_launch. | list(map(string)) | `[]` | no |
 | tags\_as\_map | A map of tags and values in the same format as other resources accept. This will be converted into the non-standard format that the aws_autoscaling_group requires. | map(string) | `{}` | no |
 | target\_group\_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list(string) | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,7 @@ resource "aws_autoscaling_group" "this" {
   metrics_granularity       = var.metrics_granularity
   wait_for_capacity_timeout = var.wait_for_capacity_timeout
   protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
 
   tags = concat(
     [
@@ -146,6 +147,7 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
   metrics_granularity       = var.metrics_granularity
   wait_for_capacity_timeout = var.wait_for_capacity_timeout
   protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
 
   initial_lifecycle_hook {
     name                    = var.initial_lifecycle_hook_name

--- a/variables.tf
+++ b/variables.tf
@@ -302,3 +302,10 @@ variable "protect_from_scale_in" {
   type        = bool
   default     = false
 }
+
+variable "service_linked_role_arn" {
+  description = "The ARN of the service-linked role that the ASG will use to call other AWS services."
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
# Description

Adds IAM service_linked_role for ASG to call EBS encryption(KMS), S3 or any other AWS services. Creating IAM role should be out of scope of this module, thus, making it a variable. Closes #63