### PR TITLE
add `encrypted` option to root_block_device

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ resource "aws_launch_configuration" "this" {
       iops                  = lookup(root_block_device.value, "iops", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
+      encrypted             = lookup(root_block_device.value, "encrypted", null)
     }
   }
 


### PR DESCRIPTION
# Description

The `root_block_device` block in `aws_launch_configuration` supports an `encrypted` parameter. This parameter was missing in the dynamic block in the module. 
https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#root_block_device
