### PR TITLE
Fix: ENI's prevent SecGrps from being destroyed on tf destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,10 @@ resource "aws_launch_configuration" "this" {
       encrypted             = lookup(root_block_device.value, "encrypted", null)
     }
   }
+  
+  network_interfaces {
+    delete_on_termination = true
+  }
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.
