### PR TITLE
fix: removed count from random pet resource #97 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,6 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
 }
 
 resource "random_pet" "asg_name" {
-  count = var.recreate_asg_when_lc_changes ? 1 : 0
 
   separator = "-"
   length    = 2


### PR DESCRIPTION
## Description
Removed count from random_pet resource

## Motivation and Context
Changing the value of "recreate_asg_when_lc_changes" from true to false in module call causes cycle errors as random_pet resource is dependent on flag

## Breaking Changes
No

## How Has This Been Tested?
removed count from random_pet resource, called module with recreate_asg_when_lc_changes flag to true. Updated module call with flag set to false

tf 0.12.10

