### PR TITLE
feat: base64 encoded user_data

### DIFF
--- a/examples/asg_ec2/main.tf
+++ b/examples/asg_ec2/main.tf
@@ -57,6 +57,13 @@ resource "aws_iam_service_linked_role" "autoscaling" {
   }
 }
 
+locals {
+  user_data = <<EOF
+#!/bin/bash
+echo "Hello Terraform!"
+EOF
+}
+
 ######
 # Launch configuration and autoscaling group
 ######
@@ -76,6 +83,8 @@ module "example" {
   security_groups              = [data.aws_security_group.default.id]
   associate_public_ip_address  = true
   recreate_asg_when_lc_changes = true
+
+  user_data_base64 = base64encode(local.user_data)
 
   ebs_block_device = [
     {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "aws_launch_configuration" "this" {
   security_groups             = var.security_groups
   associate_public_ip_address = var.associate_public_ip_address
   user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
   enable_monitoring           = var.enable_monitoring
   spot_price                  = var.spot_price
   placement_tenancy           = var.spot_price == "" ? var.placement_tenancy : ""

--- a/variables.tf
+++ b/variables.tf
@@ -125,9 +125,15 @@ variable "associate_public_ip_address" {
 }
 
 variable "user_data" {
-  description = "The user data to provide when launching the instance"
+  description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead."
   type        = string
-  default     = " "
+  default     = null
+}
+
+variable "user_data_base64" {
+  description = "Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption."
+  type        = string
+  default     = null
 }
 
 variable "enable_monitoring" {


### PR DESCRIPTION
## Description
- Add ability to use either string user_data or base64 encoded user_data similar to https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/pull/137

## Motivation and Context
closes #57

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
