### PR TITLE
fix: convert to dynamic tags to allow for empty values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.27.0
+    rev: v1.43.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict

--- a/examples/asg_ec2/main.tf
+++ b/examples/asg_ec2/main.tf
@@ -109,7 +109,7 @@ module "example" {
   health_check_type         = "EC2"
   min_size                  = 0
   max_size                  = 1
-  desired_capacity          = 0
+  desired_capacity          = 1
   wait_for_capacity_timeout = 0
   service_linked_role_arn   = aws_iam_service_linked_role.autoscaling.arn
 
@@ -124,6 +124,16 @@ module "example" {
       value               = "megasecret"
       propagate_at_launch = true
     },
+    {
+      key                 = "foo"
+      value               = ""
+      propagate_at_launch = true
+    },
+    {
+      key                 = "bar"
+      value               = ""
+      propagate_at_launch = true
+    }
   ]
 
   tags_as_map = {

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,16 @@
 locals {
+  tags = concat(
+    [
+      {
+        "key"                 = "Name"
+        "value"               = var.name
+        "propagate_at_launch" = true
+      },
+    ],
+    var.tags,
+    local.tags_asg_format,
+  )
+
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 }
 

--- a/main.tf
+++ b/main.tf
@@ -96,17 +96,14 @@ resource "aws_autoscaling_group" "this" {
   service_linked_role_arn   = var.service_linked_role_arn
   max_instance_lifetime     = var.max_instance_lifetime
 
-  tags = concat(
-    [
-      {
-        "key"                 = "Name"
-        "value"               = var.name
-        "propagate_at_launch" = true
-      },
-    ],
-    var.tags,
-    local.tags_asg_format,
-  )
+  dynamic "tag" {
+    for_each = local.tags
+    content {
+      key                 = tag.value["key"]
+      value               = tag.value["value"]
+      propagate_at_launch = tag.value["propagate_at_launch"]
+    }
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -162,17 +159,14 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
     default_result          = var.initial_lifecycle_hook_default_result
   }
 
-  tags = concat(
-    [
-      {
-        "key"                 = "Name"
-        "value"               = var.name
-        "propagate_at_launch" = true
-      },
-    ],
-    var.tags,
-    local.tags_asg_format,
-  )
+  dynamic "tag" {
+    for_each = local.tags
+    content {
+      key                 = tag.value["key"]
+      value               = tag.value["value"]
+      propagate_at_launch = tag.value["propagate_at_launch"]
+    }
+  }
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description
- convert tags to dynamic tags to allow for empty values. this is the workaround solution described here https://github.com/terraform-providers/terraform-provider-aws/issues/9049
- update pre-commit hooks to latest 

<img width="887" alt="image" src="https://user-images.githubusercontent.com/10913471/94558721-3a9c3900-022e-11eb-829a-d6d638b84f60.png">

## Motivation and Context
- Closes #102

## Breaking Changes
No

## How Has This Been Tested?
`asg_ec2` example has been updated to include the empty tags and when deployed it works as expected
