### PR TITLE
fix: Launch template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,14 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 |------|-------------|------|---------|:--------:|
 | asg\_name | Creates a unique name for autoscaling group beginning with the specified prefix | `string` | `""` | no |
 | associate\_public\_ip\_address | Associate a public ip address with an instance in a VPC | `bool` | `false` | no |
+| block\_device\_mappings | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
+| capacity\_rebalance | Indicates whether capacity rebalance is enabled. | `bool` | `true` | no |
 | create\_asg | Whether to create autoscaling group | `bool` | `true` | no |
 | create\_asg\_with\_initial\_lifecycle\_hook | Create an ASG with initial lifecycle hook | `bool` | `false` | no |
 | create\_lc | Whether to create launch configuration | `bool` | `true` | no |
+| create\_lt | launch template instead launch configuration | `bool` | `false` | no |
 | default\_cooldown | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `300` | no |
+| delete\_interfaces\_on\_termination | Whether the network interface should be destroyed on instance termination. (Launch template only.) | `bool` | `true` | no |
 | desired\_capacity | The number of Amazon EC2 instances that should be running in the group | `string` | n/a | yes |
 | ebs\_block\_device | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
@@ -160,10 +164,13 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | instance\_type | The size of instance to launch | `string` | `""` | no |
 | key\_name | The key name that should be used for the instance | `string` | `""` | no |
 | launch\_configuration | The name of the launch configuration to use (if it is created outside of this module) | `string` | `""` | no |
+| launch\_template | The id of the launch template to use (if it is created outside of this module) | `string` | `""` | no |
 | lc\_name | Creates a unique name for launch configuration beginning with the specified prefix | `string` | `""` | no |
 | load\_balancers | A list of elastic load balancer names to add to the autoscaling group names | `list(string)` | `[]` | no |
 | max\_instance\_lifetime | The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds. | `number` | `0` | no |
 | max\_size | The maximum size of the auto scale group | `string` | n/a | yes |
+| metadata\_hop\_limit | The desired HTTP PUT response hop limit for instance metadata requests. (Launch template only.) | `number` | `1` | no |
+| metadata\_http\_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. (Launch template only.) | `string` | `"optional"` | no |
 | metrics\_granularity | The granularity to associate with the metrics to collect. The only valid value is 1Minute | `string` | `"1Minute"` | no |
 | min\_elb\_capacity | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | `number` | `0` | no |
 | min\_size | The minimum size of the auto scale group | `string` | n/a | yes |
@@ -206,6 +213,8 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | this\_autoscaling\_group\_vpc\_zone\_identifier | The VPC zone identifier |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
 | this\_launch\_configuration\_name | The name of the launch configuration |
+| this\_launch\_template\_id | The ID of the launch template |
+| this\_launch\_template\_name | The name of the launch template |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ No Modules.
 |------|
 | [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) |
 | [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| [aws_launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) |
 | [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
 | [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,6 @@ resource "aws_launch_configuration" "this" {
 ##################
 # Launch template
 ##################
-
 resource "aws_launch_template" "this" {
   count         = var.create_lt ? 1 : 0
   name          = "lt-${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -56,18 +56,18 @@ resource "aws_launch_configuration" "this" {
   }
 }
 
-####################
+##################
 # Launch template
-####################
+##################
 
 resource "aws_launch_template" "this" {
-  count                  = var.create_lt ? 1 : 0
-  name                   = "lt-${var.name}"
-  user_data              = var.user_data_base64 != null ? var.user_data_base64 : (var.user_data != null ? base64encode(var.user_data) : null)
-  image_id               = var.image_id
-  instance_type          = var.instance_type
-  key_name               = var.key_name
-  ebs_optimized          = var.ebs_optimized
+  count         = var.create_lt ? 1 : 0
+  name          = "lt-${var.name}"
+  user_data     = var.user_data_base64 != null ? var.user_data_base64 : (var.user_data != null ? base64encode(var.user_data) : null)
+  image_id      = var.image_id
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  ebs_optimized = var.ebs_optimized
 
   metadata_options {
     http_endpoint               = "enabled"
@@ -102,11 +102,11 @@ resource "aws_launch_template" "this" {
   }
 }
 
-####################
+#########################################
 # Autoscaling group with launch template
-####################
+#########################################
 resource "aws_autoscaling_group" "this_with_launchtemplate" {
-  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lt || var.launch_template_id != "") ? 1 : 0
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lt || var.launch_template != "") ? 1 : 0
 
   name_prefix = "${join(
     "-",
@@ -119,10 +119,9 @@ resource "aws_autoscaling_group" "this_with_launchtemplate" {
   )}-"
 
   launch_template {
-    id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : var.launch_template_id
+    id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : var.launch_template
     version = "$Latest"
   }
-
 
   vpc_zone_identifier = var.vpc_zone_identifier
   max_size            = var.max_size
@@ -166,9 +165,9 @@ resource "aws_autoscaling_group" "this_with_launchtemplate" {
   }
 }
 
-####################
+##############################################
 # Autoscaling group with launch configuration
-####################
+##############################################
 resource "aws_autoscaling_group" "this" {
   count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lc || var.launch_configuration != "") ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -155,7 +155,7 @@ resource "aws_autoscaling_group" "this_with_launchtemplate" {
   )}-"
 
   launch_template {
-    id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : null
+    id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : var.launch_template_id
     version = "$Latest"
   }
 
@@ -219,8 +219,6 @@ resource "aws_autoscaling_group" "this" {
   )}-"
 
   launch_configuration = var.create_lc ? element(concat(aws_launch_configuration.this.*.name, [""]), 0) : var.launch_configuration
-
-
 
   vpc_zone_identifier = var.vpc_zone_identifier
   max_size            = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ resource "aws_launch_template" "this" {
 # Autoscaling group with launch template
 ####################
 resource "aws_autoscaling_group" "this_with_launchtemplate" {
-  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && var.create_lt ? 1 : 0
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lt || var.launch_template_id != "")? 1 : 0
 
   name_prefix = "${join(
     "-",
@@ -206,7 +206,7 @@ resource "aws_autoscaling_group" "this_with_launchtemplate" {
 # Autoscaling group with launch configuration
 ####################
 resource "aws_autoscaling_group" "this" {
-  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && var.create_lc ? 1 : 0
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lc || var.launch_configuration != "") ? 1 : 0
 
   name_prefix = "${join(
     "-",

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_launch_template" "this" {
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "required"
+    http_tokens                 = var.http_tokens
     http_put_response_hop_limit = 1
   }
   monitoring {

--- a/main.tf
+++ b/main.tf
@@ -100,42 +100,6 @@ resource "aws_launch_template" "this" {
       }
     }
   }
-  /*
-  capacity_reservation_specification {
-    capacity_reservation_preference = "open"
-  }
-  cpu_options {
-    core_count       = 4
-    threads_per_core = 2
-  }
-  credit_specification {
-    cpu_credits = "standard"
-  }
-  disable_api_termination = true
-  ebs_optimized = true
-
-  instance_initiated_shutdown_behavior = "terminate"
-  instance_market_options {
-    market_type = "spot"
-  }
-  kernel_id = "test"
-  license_specification {
-    license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
-  }
-
-
-  placement {
-    availability_zone = "us-west-2a"
-  }
-  ram_disk_id = "test"
-  vpc_security_group_ids = ["sg-12345678"]
-  tag_specifications {
-    resource_type = "instance"
-    tags = {
-      Name = "test"
-    }
-  }
-} */
 }
 
 ####################

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,7 @@ resource "aws_launch_template" "this" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = var.security_groups
+    delete_on_termination       = var.delete_interfaces_on_termination
   }
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/main.tf
+++ b/main.tf
@@ -61,14 +61,14 @@ resource "aws_launch_configuration" "this" {
 ####################
 
 resource "aws_launch_template" "this" {
-  count = var.create_lt ? 1 : 0
-  name = "lt-${var.name}"
-  user_data                   = var.user_data
-  image_id                    = var.image_id
-  instance_type               = var.instance_type
-  key_name                    = var.key_name
+  count         = var.create_lt ? 1 : 0
+  name          = "lt-${var.name}"
+  user_data     = var.user_data
+  image_id      = var.image_id
+  instance_type = var.instance_type
+  key_name      = var.key_name
   #vpc_security_group_ids      = var.security_groups
-  ebs_optimized               = var.ebs_optimized
+  ebs_optimized = var.ebs_optimized
 
   metadata_options {
     http_endpoint               = "enabled"
@@ -83,13 +83,13 @@ resource "aws_launch_template" "this" {
   }
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
-    security_groups = var.security_groups
+    security_groups             = var.security_groups
   }
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
     content {
-      device_name           = block_device_mappings.value.device_name
-      no_device             = lookup(block_device_mappings.value, "no_device", null)
+      device_name = block_device_mappings.value.device_name
+      no_device   = lookup(block_device_mappings.value, "no_device", null)
       ebs {
         delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", null)
         encrypted             = lookup(block_device_mappings.value, "encrypted", null)
@@ -100,7 +100,7 @@ resource "aws_launch_template" "this" {
       }
     }
   }
-/*
+  /*
   capacity_reservation_specification {
     capacity_reservation_preference = "open"
   }
@@ -155,15 +155,16 @@ resource "aws_autoscaling_group" "this_with_launchtemplate" {
   )}-"
 
   launch_template {
-      id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : null
-      version = "$Latest"
-    }
+    id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : null
+    version = "$Latest"
+  }
 
 
-  vpc_zone_identifier  = var.vpc_zone_identifier
-  max_size             = var.max_size
-  min_size             = var.min_size
-  desired_capacity     = var.desired_capacity
+  vpc_zone_identifier = var.vpc_zone_identifier
+  max_size            = var.max_size
+  min_size            = var.min_size
+  desired_capacity    = var.desired_capacity
+  capacity_rebalance  = var.capacity_rebalance
 
   load_balancers            = var.load_balancers
   health_check_grace_period = var.health_check_grace_period
@@ -221,10 +222,11 @@ resource "aws_autoscaling_group" "this" {
 
 
 
-  vpc_zone_identifier  = var.vpc_zone_identifier
-  max_size             = var.max_size
-  min_size             = var.min_size
-  desired_capacity     = var.desired_capacity
+  vpc_zone_identifier = var.vpc_zone_identifier
+  max_size            = var.max_size
+  min_size            = var.min_size
+  desired_capacity    = var.desired_capacity
+  capacity_rebalance  = var.capacity_rebalance
 
   load_balancers            = var.load_balancers
   health_check_grace_period = var.health_check_grace_period
@@ -279,6 +281,7 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
   max_size             = var.max_size
   min_size             = var.min_size
   desired_capacity     = var.desired_capacity
+  capacity_rebalance   = var.capacity_rebalance
 
   load_balancers            = var.load_balancers
   health_check_grace_period = var.health_check_grace_period

--- a/main.tf
+++ b/main.tf
@@ -61,14 +61,13 @@ resource "aws_launch_configuration" "this" {
 ####################
 
 resource "aws_launch_template" "this" {
-  count         = var.create_lt ? 1 : 0
-  name          = "lt-${var.name}"
-  user_data     = var.user_data
-  image_id      = var.image_id
-  instance_type = var.instance_type
-  key_name      = var.key_name
-  #vpc_security_group_ids      = var.security_groups
-  ebs_optimized = var.ebs_optimized
+  count                  = var.create_lt ? 1 : 0
+  name                   = "lt-${var.name}"
+  user_data              = var.user_data_base64 != null ? var.user_data_base64 : (var.user_data != null ? base64encode(var.user_data) : null)
+  image_id               = var.image_id
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  ebs_optimized          = var.ebs_optimized
 
   metadata_options {
     http_endpoint               = "enabled"
@@ -142,7 +141,7 @@ resource "aws_launch_template" "this" {
 # Autoscaling group with launch template
 ####################
 resource "aws_autoscaling_group" "this_with_launchtemplate" {
-  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lt || var.launch_template_id != "")? 1 : 0
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && (var.create_lt || var.launch_template_id != "") ? 1 : 0
 
   name_prefix = "${join(
     "-",

--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,8 @@ resource "aws_launch_template" "this" {
 
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = var.http_tokens
-    http_put_response_hop_limit = 1
+    http_tokens                 = var.metadata_http_tokens
+    http_put_response_hop_limit = var.metadata_hop_limit
   }
   monitoring {
     enabled = var.enable_monitoring

--- a/main.tf
+++ b/main.tf
@@ -57,10 +57,92 @@ resource "aws_launch_configuration" "this" {
 }
 
 ####################
-# Autoscaling group
+# Launch template
 ####################
-resource "aws_autoscaling_group" "this" {
-  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook ? 1 : 0
+
+resource "aws_launch_template" "this" {
+  count = var.create_lt ? 1 : 0
+  name = "lt-${var.name}"
+  user_data                   = var.user_data
+  image_id                    = var.image_id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  #vpc_security_group_ids      = var.security_groups
+  ebs_optimized               = var.ebs_optimized
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+  monitoring {
+    enabled = var.enable_monitoring
+  }
+  iam_instance_profile {
+    name = var.iam_instance_profile
+  }
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups = var.security_groups
+  }
+  dynamic "block_device_mappings" {
+    for_each = var.block_device_mappings
+    content {
+      device_name           = block_device_mappings.value.device_name
+      no_device             = lookup(block_device_mappings.value, "no_device", null)
+      ebs {
+        delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", null)
+        encrypted             = lookup(block_device_mappings.value, "encrypted", null)
+        iops                  = lookup(block_device_mappings.value, "iops", null)
+        snapshot_id           = lookup(block_device_mappings.value, "snapshot_id", null)
+        volume_size           = lookup(block_device_mappings.value, "volume_size", null)
+        volume_type           = lookup(block_device_mappings.value, "volume_type", null)
+      }
+    }
+  }
+/*
+  capacity_reservation_specification {
+    capacity_reservation_preference = "open"
+  }
+  cpu_options {
+    core_count       = 4
+    threads_per_core = 2
+  }
+  credit_specification {
+    cpu_credits = "standard"
+  }
+  disable_api_termination = true
+  ebs_optimized = true
+
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_market_options {
+    market_type = "spot"
+  }
+  kernel_id = "test"
+  license_specification {
+    license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
+  }
+
+
+  placement {
+    availability_zone = "us-west-2a"
+  }
+  ram_disk_id = "test"
+  vpc_security_group_ids = ["sg-12345678"]
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "test"
+    }
+  }
+} */
+}
+
+####################
+# Autoscaling group with launch template
+####################
+resource "aws_autoscaling_group" "this_with_launchtemplate" {
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && var.create_lt ? 1 : 0
 
   name_prefix = "${join(
     "-",
@@ -71,7 +153,74 @@ resource "aws_autoscaling_group" "this" {
       ],
     ),
   )}-"
+
+  launch_template {
+      id      = var.create_lt ? element(concat(aws_launch_template.this.*.id, [""]), 0) : null
+      version = "$Latest"
+    }
+
+
+  vpc_zone_identifier  = var.vpc_zone_identifier
+  max_size             = var.max_size
+  min_size             = var.min_size
+  desired_capacity     = var.desired_capacity
+
+  load_balancers            = var.load_balancers
+  health_check_grace_period = var.health_check_grace_period
+  health_check_type         = var.health_check_type
+
+  min_elb_capacity          = var.min_elb_capacity
+  wait_for_elb_capacity     = var.wait_for_elb_capacity
+  target_group_arns         = var.target_group_arns
+  default_cooldown          = var.default_cooldown
+  force_delete              = var.force_delete
+  termination_policies      = var.termination_policies
+  suspended_processes       = var.suspended_processes
+  placement_group           = var.placement_group
+  enabled_metrics           = var.enabled_metrics
+  metrics_granularity       = var.metrics_granularity
+  wait_for_capacity_timeout = var.wait_for_capacity_timeout
+  protect_from_scale_in     = var.protect_from_scale_in
+  service_linked_role_arn   = var.service_linked_role_arn
+  max_instance_lifetime     = var.max_instance_lifetime
+
+  tags = concat(
+    [
+      {
+        "key"                 = "Name"
+        "value"               = var.name
+        "propagate_at_launch" = true
+      },
+    ],
+    var.tags,
+    local.tags_asg_format,
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+####################
+# Autoscaling group with launch configuration
+####################
+resource "aws_autoscaling_group" "this" {
+  count = var.create_asg && false == var.create_asg_with_initial_lifecycle_hook && var.create_lc ? 1 : 0
+
+  name_prefix = "${join(
+    "-",
+    compact(
+      [
+        coalesce(var.asg_name, var.name),
+        var.recreate_asg_when_lc_changes ? element(concat(random_pet.asg_name.*.id, [""]), 0) : "",
+      ],
+    ),
+  )}-"
+
   launch_configuration = var.create_lc ? element(concat(aws_launch_configuration.this.*.name, [""]), 0) : var.launch_configuration
+
+
+
   vpc_zone_identifier  = var.vpc_zone_identifier
   max_size             = var.max_size
   min_size             = var.min_size

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,9 @@ locals {
   this_launch_configuration_id   = var.launch_configuration == "" && var.create_lc ? concat(aws_launch_configuration.this.*.id, [""])[0] : var.launch_configuration
   this_launch_configuration_name = var.launch_configuration == "" && var.create_lc ? concat(aws_launch_configuration.this.*.name, [""])[0] : ""
 
+  this_launch_template_id   = var.launch_template == "" && var.create_lt ? concat(aws_launch_template.this.*.id, [""])[0] : var.launch_template
+  this_launch_template_name = var.launch_template == "" && var.create_lt ? concat(aws_launch_template.this.*.name, [""])[0] : ""
+
   this_autoscaling_group_id                        = concat(aws_autoscaling_group.this.*.id, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.id, aws_autoscaling_group.this_with_launchtemplate.*.id, [""])[0]
   this_autoscaling_group_name                      = concat(aws_autoscaling_group.this.*.name, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.name, aws_autoscaling_group.this_with_launchtemplate.*.name, [""])[0]
   this_autoscaling_group_arn                       = concat(aws_autoscaling_group.this.*.arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.arn, aws_autoscaling_group.this_with_launchtemplate.*.arn, [""])[0]
@@ -25,6 +28,16 @@ output "this_launch_configuration_id" {
 output "this_launch_configuration_name" {
   description = "The name of the launch configuration"
   value       = local.this_launch_configuration_name
+}
+
+output "this_launch_template_id" {
+  description = "The ID of the launch template"
+  value       = local.this_launch_template_id
+}
+
+output "this_launch_template_name" {
+  description = "The name of the launch template"
+  value       = local.this_launch_template_name
 }
 
 output "this_autoscaling_group_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,19 +2,19 @@ locals {
   this_launch_configuration_id   = var.launch_configuration == "" && var.create_lc ? concat(aws_launch_configuration.this.*.id, [""])[0] : var.launch_configuration
   this_launch_configuration_name = var.launch_configuration == "" && var.create_lc ? concat(aws_launch_configuration.this.*.name, [""])[0] : ""
 
-  this_autoscaling_group_id                        = concat(aws_autoscaling_group.this.*.id, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.id, [""])[0]
-  this_autoscaling_group_name                      = concat(aws_autoscaling_group.this.*.name, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.name, [""])[0]
-  this_autoscaling_group_arn                       = concat(aws_autoscaling_group.this.*.arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.arn, [""])[0]
-  this_autoscaling_group_min_size                  = concat(aws_autoscaling_group.this.*.min_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.min_size, [""])[0]
-  this_autoscaling_group_max_size                  = concat(aws_autoscaling_group.this.*.max_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.max_size, [""])[0]
-  this_autoscaling_group_desired_capacity          = concat(aws_autoscaling_group.this.*.desired_capacity, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.desired_capacity, [""])[0]
-  this_autoscaling_group_default_cooldown          = concat(aws_autoscaling_group.this.*.default_cooldown, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.default_cooldown, [""])[0]
-  this_autoscaling_group_health_check_grace_period = concat(aws_autoscaling_group.this.*.health_check_grace_period, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_grace_period, [""])[0]
-  this_autoscaling_group_health_check_type         = concat(aws_autoscaling_group.this.*.health_check_type, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_type, [""])[0]
-  this_autoscaling_group_availability_zones        = concat(aws_autoscaling_group.this.*.availability_zones, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.availability_zones, [""])[0]
-  this_autoscaling_group_vpc_zone_identifier       = concat(aws_autoscaling_group.this.*.vpc_zone_identifier, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.vpc_zone_identifier, [""])[0]
-  this_autoscaling_group_load_balancers            = concat(aws_autoscaling_group.this.*.load_balancers, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.load_balancers, [""])[0]
-  this_autoscaling_group_target_group_arns         = concat(aws_autoscaling_group.this.*.target_group_arns, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.target_group_arns, [""])[0]
+  this_autoscaling_group_id                        = concat(aws_autoscaling_group.this.*.id, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.id, aws_autoscaling_group.this_with_launchtemplate.*.id, [""])[0]
+  this_autoscaling_group_name                      = concat(aws_autoscaling_group.this.*.name, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.name, aws_autoscaling_group.this_with_launchtemplate.*.name, [""])[0]
+  this_autoscaling_group_arn                       = concat(aws_autoscaling_group.this.*.arn, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.arn, aws_autoscaling_group.this_with_launchtemplate.*.arn, [""])[0]
+  this_autoscaling_group_min_size                  = concat(aws_autoscaling_group.this.*.min_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.min_size, aws_autoscaling_group.this_with_launchtemplate.*.min_size, [""])[0]
+  this_autoscaling_group_max_size                  = concat(aws_autoscaling_group.this.*.max_size, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.max_size, aws_autoscaling_group.this_with_launchtemplate.*.max_size, [""])[0]
+  this_autoscaling_group_desired_capacity          = concat(aws_autoscaling_group.this.*.desired_capacity, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.desired_capacity, aws_autoscaling_group.this_with_launchtemplate.*.desired_capacity, [""])[0]
+  this_autoscaling_group_default_cooldown          = concat(aws_autoscaling_group.this.*.default_cooldown, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.default_cooldown, aws_autoscaling_group.this_with_launchtemplate.*.default_cooldown, [""])[0]
+  this_autoscaling_group_health_check_grace_period = concat(aws_autoscaling_group.this.*.health_check_grace_period, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_grace_period, aws_autoscaling_group.this_with_launchtemplate.*.health_check_grace_period, [""])[0]
+  this_autoscaling_group_health_check_type         = concat(aws_autoscaling_group.this.*.health_check_type, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.health_check_type, aws_autoscaling_group.this_with_launchtemplate.*.health_check_type, [""])[0]
+  this_autoscaling_group_availability_zones        = concat(aws_autoscaling_group.this.*.availability_zones, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.availability_zones, aws_autoscaling_group.this_with_launchtemplate.*.availability_zones, [""])[0]
+  this_autoscaling_group_vpc_zone_identifier       = concat(aws_autoscaling_group.this.*.vpc_zone_identifier, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.vpc_zone_identifier, aws_autoscaling_group.this_with_launchtemplate.*.vpc_zone_identifier, [""])[0]
+  this_autoscaling_group_load_balancers            = concat(aws_autoscaling_group.this.*.load_balancers, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.load_balancers, aws_autoscaling_group.this_with_launchtemplate.*.load_balancers, [""])[0]
+  this_autoscaling_group_target_group_arns         = concat(aws_autoscaling_group.this.*.target_group_arns, aws_autoscaling_group.this_with_initial_lifecycle_hook.*.target_group_arns, aws_autoscaling_group.this_with_launchtemplate.*.target_group_arns, [""])[0]
 }
 
 output "this_launch_configuration_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create_lc" {
   default     = true
 }
 
+variable "create_lt" {
+  description = "launch template instead launch configuration"
+  type        = bool
+  default     = false
+}
+
 variable "create_asg" {
   description = "Whether to create autoscaling group"
   type        = bool
@@ -155,6 +161,12 @@ variable "root_block_device" {
 }
 
 variable "ebs_block_device" {
+  description = "Additional EBS block devices to attach to the instance"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "block_device_mappings"  {
   description = "Additional EBS block devices to attach to the instance"
   type        = list(map(string))
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -166,7 +166,7 @@ variable "ebs_block_device" {
   default     = []
 }
 
-variable "block_device_mappings"  {
+variable "block_device_mappings" {
   description = "Additional EBS block devices to attach to the instance"
   type        = list(map(string))
   default     = []
@@ -334,7 +334,13 @@ variable "max_instance_lifetime" {
 }
 
 variable "http_tokens" {
-  description = "http tokens"
-  type = string
-  default = "optional"
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
+  type        = string
+  default     = "optional"
+}
+
+variable "capacity_rebalance" {
+  description = "Indicates whether capacity rebalance is enabled."
+  type        = bool
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "launch_configuration" {
   default     = ""
 }
 
+variable "launch_template_id" {
+  description = "The id of the launch template to use (if it is created outside of this module)"
+  type        = string
+  default     = ""
+}
+
 # Launch configuration
 variable "image_id" {
   description = "The EC2 image ID to launch"

--- a/variables.tf
+++ b/variables.tf
@@ -340,13 +340,19 @@ variable "max_instance_lifetime" {
 }
 
 variable "http_tokens" {
-  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2."
+  description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. (Launch template only.)"
   type        = string
   default     = "optional"
 }
 
 variable "capacity_rebalance" {
   description = "Indicates whether capacity rebalance is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "delete_interfaces_on_termination" {
+  description = "Whether the network interface should be destroyed on instance termination. (Launch template only.)"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "launch_configuration" {
   default     = ""
 }
 
-variable "launch_template_id" {
+variable "launch_template" {
   description = "The id of the launch template to use (if it is created outside of this module)"
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -333,3 +333,8 @@ variable "max_instance_lifetime" {
   default     = 0
 }
 
+variable "http_tokens" {
+  description = "http tokens"
+  type = string
+  default = "optional"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -339,10 +339,16 @@ variable "max_instance_lifetime" {
   default     = 0
 }
 
-variable "http_tokens" {
+variable "metadata_http_tokens" {
   description = "Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2. (Launch template only.)"
   type        = string
   default     = "optional"
+}
+
+variable "metadata_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests. (Launch template only.)"
+  type        = number
+  default     = 1
 }
 
 variable "capacity_rebalance" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There are more and more features added to AWS EC2, and there are a few whic are only supported by Launch Templates and missed out from Launch Configurations.
This PR adds (an opinionated) support for Launch templates, while keeping backward compatibility.

This work is based on Jay's fork at https://github.com/tadaima-studio/terraform-aws-autoscaling, thanks Jay!

Fixes #54 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No known breaking changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using [pre-commit](https://pre-commit.com/), and also used to deploy one of our clusters. No issues so far. :smiley: 
