### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | null | >= 2.0 |
 | random | >= 2.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/autoscaling_group) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/launch_configuration) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2.0/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -206,7 +219,6 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | this\_autoscaling\_group\_vpc\_zone\_identifier | The VPC zone identifier |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
 | this\_launch\_configuration\_name | The name of the launch configuration |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/asg_ec2/README.md
+++ b/examples/asg_ec2/README.md
@@ -30,6 +30,22 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.41 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| example | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
+| [aws_iam_service_linked_role](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/iam_service_linked_role) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -44,5 +60,4 @@ No input.
 | this\_autoscaling\_group\_target\_group\_arns | List of Target Group ARNs that apply to this AutoScaling Group |
 | this\_autoscaling\_group\_vpc\_zone\_identifier | The VPC zone identifier |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_ec2_external_launch_configuration/README.md
+++ b/examples/asg_ec2_external_launch_configuration/README.md
@@ -30,6 +30,21 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.41 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| example | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/launch_configuration) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -40,5 +55,4 @@ No input.
 |------|-------------|
 | this\_autoscaling\_group\_id | The autoscaling group id |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_elb/README.md
+++ b/examples/asg_elb/README.md
@@ -30,6 +30,22 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.41 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| elb | terraform-aws-modules/elb/aws |  |
+| example_asg | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -41,5 +57,4 @@ No input.
 | this\_autoscaling\_group\_id | The autoscaling group id |
 | this\_elb\_dns\_name | DNS Name of the ELB |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/asg_inital_lifecycle_hook/README.md
+++ b/examples/asg_inital_lifecycle_hook/README.md
@@ -30,6 +30,21 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.41 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| example | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -40,5 +55,4 @@ No input.
 |------|-------------|
 | this\_autoscaling\_group\_id | The autoscaling group id |
 | this\_launch\_configuration\_id | The ID of the launch configuration |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
