### PR TITLE
chore: only run validate check on min terraform version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,4 +52,11 @@ jobs:
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
 
       - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
+        run: pre-commit run --color=always --show-diff-on-failure --all-files terraform_validate
+
+      - name: Execute pre-commit
+        # Run all pre-commit checks on max version supported
+        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
         run: pre-commit run --color=always --show-diff-on-failure --all-files


### PR DESCRIPTION
## Description
- only run validate check on min terraform version

## Motivation and Context
- validate will run on both min and max supported terraform versions, but format, lint, and docs will only run on max/latest version of terraform supported

## Breaking Changes
- no

## How Has This Been Tested?
- static check github action
