### PR TITLE
chore: align ci-cd static checks to use individual minimum Terraform versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,14 +7,65 @@ on:
       - master
 
 jobs:
-  getBaseVersion:
-    name: Get min/max versions
-    runs-on: ubuntu-latest
+# Min Terraform version(s)
+  getDirectories:
+      name: Get root directories
+      runs-on: ubuntu-latest
+      steps:
+          - name: Checkout
+            uses: actions/checkout@v2
+          - name: Install Python
+            uses: actions/setup-python@v2
+          - name: Build matrix
+            id: matrix
+            run: |
+              DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
+              echo "::set-output name=directories::$DIRS"
+      outputs:
+          directories: ${{ steps.matrix.outputs.directories }}
 
+  preCommitMinVersions:
+    name: Min TF validate
+    needs: getDirectories
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.0.1
+        with:
+          directory: ${{ matrix.directory }}
+      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ steps.minMax.outputs.minVersion }}
+      - name: Install pre-commit dependencies
+        run: pip install pre-commit
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory !=  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*
+      - name: Execute pre-commit
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory ==  '.' }}
+        run:
+          pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
 
+
+# Max Terraform version
+  getBaseVersion:
+    name: Module max TF version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Terraform min/max versions
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.1
@@ -22,40 +73,29 @@ jobs:
       minVersion: ${{ steps.minMax.outputs.minVersion }}
       maxVersion: ${{ steps.minMax.outputs.maxVersion }}
 
-  preCommit:
-    name: Pre-commit check
+  preCommitMaxVersion:
+    name: Max TF pre-commit
     runs-on: ubuntu-latest
     needs: getBaseVersion
     strategy:
       fail-fast: false
       matrix:
         version:
-          - ${{ needs.getBaseVersion.outputs.minVersion }}
           - ${{ needs.getBaseVersion.outputs.maxVersion }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Install Python
         uses: actions/setup-python@v2
-
       - name: Install Terraform v${{ matrix.version }}
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ matrix.version }}
-
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-
-      - name: Execute pre-commit
-        # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.minVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files terraform_validate
-
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.46.0
+    rev: v1.47.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ No Modules.
 
 | Name |
 |------|
-| [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/autoscaling_group) |
-| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/launch_configuration) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2.0/docs/resources/resource) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+| [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
 
 ## Inputs
 

--- a/examples/asg_ec2/README.md
+++ b/examples/asg_ec2/README.md
@@ -40,11 +40,11 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
-| [aws_iam_service_linked_role](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/iam_service_linked_role) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_iam_service_linked_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
 
 ## Inputs
 

--- a/examples/asg_ec2_external_launch_configuration/README.md
+++ b/examples/asg_ec2_external_launch_configuration/README.md
@@ -40,10 +40,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
-| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/resources/launch_configuration) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
 
 ## Inputs
 

--- a/examples/asg_elb/README.md
+++ b/examples/asg_elb/README.md
@@ -41,10 +41,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
 
 ## Inputs
 

--- a/examples/asg_inital_lifecycle_hook/README.md
+++ b/examples/asg_inital_lifecycle_hook/README.md
@@ -40,10 +40,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name |
 |------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/ami) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/security_group) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.41/docs/data-sources/vpc) |
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
 
 ## Inputs
 


### PR DESCRIPTION
## Description
- align ci-cd static checks to use individual minimum Terraform versions

## Motivation and Context
- ensure that the modules are all following a similar workflow and the static checks that performed

## Breaking Changes
- No

## How Has This Been Tested?
- ci-cd static checks