### PR TITLE
fix: add tags to launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,6 +298,8 @@ resource "aws_launch_template" "this" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = var.tags_as_map
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- add tags to launch template

## Motivation and Context
- tags attribute was overlooked for launch template resource and tags were not added

Closes #140

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
