### PR TITLE
feat: Add support for `warm_pool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,11 +361,11 @@ No modules.
 | <a name="input_use_mixed_instances_policy"></a> [use\_mixed\_instances\_policy](#input\_use\_mixed\_instances\_policy) | Determines whether to use a mixed instances policy in the autoscaling group or not | `bool` | `false` | no |
 | <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix | `bool` | `true` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | (LC) The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument nor when using Launch Templates; see `user_data_base64` instead | `string` | `null` | no |
-| <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | The Base64-encoded user data to provide when launching the instance. You should use this for Launch Templates instead using input_user_data | `string` | `null` | no |
+| <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | The Base64-encoded user data to provide when launching the instance. You should use this for Launch Templates instead user\_data | `string` | `null` | no |
 | <a name="input_vpc_zone_identifier"></a> [vpc\_zone\_identifier](#input\_vpc\_zone\_identifier) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `null` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior. | `number` | `null` | no |
-| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group. | `any` | `null` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group | `any` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ No modules.
 | <a name="input_vpc_zone_identifier"></a> [vpc\_zone\_identifier](#input\_vpc\_zone\_identifier) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `null` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior. | `number` | `null` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group. | `any` | `null` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -56,6 +56,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_lt_only"></a> [lt\_only](#module\_lt\_only) | ../../ |  |
 | <a name="module_mixed_instance"></a> [mixed\_instance](#module\_mixed\_instance) | ../../ |  |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_warmed_lt"></a> [warmed\_lt](#module\_warmed\_lt) | ../../ |  |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -697,3 +697,35 @@ module "mixed_instance" {
   tags        = local.tags
   tags_as_map = local.tags_as_map
 }
+
+################################################################################
+# With warm pool
+################################################################################
+
+module "warmed_lt" {
+  source = "../../"
+
+  # Autoscaling group
+  name = "warmed-lt-${local.name}"
+
+  vpc_zone_identifier = module.vpc.private_subnets
+  min_size            = 0
+  max_size            = 1
+  desired_capacity    = 1
+
+  # Launch template
+  use_lt    = true
+  create_lt = true
+
+  image_id      = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+
+  warm_pool = {
+    pool_state                  = "Stopped"
+    min_size                    = 1
+    max_group_prepared_capacity = 2
+  }
+
+  tags        = local.tags
+  tags_as_map = local.tags_as_map
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.30"
+      version = ">= 3.37"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -420,6 +420,15 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
+  dynamic "warm_pool" {
+    for_each = var.warm_pool != null ? [var.warm_pool] : []
+    content {
+      pool_state                  = lookup(warm_pool.value, "pool_state", null)
+      min_size                    = lookup(warm_pool.value, "min_size", null)
+      max_group_prepared_capacity = lookup(warm_pool.value, "max_group_prepared_capacity", null)
+    }
+  }
+
   timeouts {
     delete = var.delete_timeout
   }

--- a/variables.tf
+++ b/variables.tf
@@ -223,6 +223,12 @@ variable "propagate_name" {
   default     = true
 }
 
+variable "warm_pool" {
+  description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group"
+  type        = any
+  default     = null
+}
+
 ################################################################################
 # Common - launch configuration or launch template
 ################################################################################


### PR DESCRIPTION
## Description
Adds support for `aws_autoscaling_group`'s `warm_pool` configuration.

## Motivation and Context
This isn't a hill I need to die on. If this change is risky for some reason that's non-obvious to me, we can forego a merge of this.

## Breaking Changes
This is a relatively new feature to the underlying `aws` provider: https://github.com/hashicorp/terraform-provider-aws/pull/18734

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

See supplied example.
