### PR TITLE
fix: Added variable to control propagation of the ASG Name tag to instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ No modules.
 | <a name="input_placement"></a> [placement](#input\_placement) | (LT) The placement of the instance | `map(string)` | `null` | no |
 | <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The name of the placement group into which you'll launch your instances, if any | `string` | `null` | no |
 | <a name="input_placement_tenancy"></a> [placement\_tenancy](#input\_placement\_tenancy) | (LC) The tenancy of the instance. Valid values are `default` or `dedicated` | `string` | `null` | no |
+| <a name="input_propagate_name"></a> [propagate\_name](#input\_propagate\_name) | Determines whether to propagate the ASG Name tag or not | `bool` | `true` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | (LT) The ID of the ram disk | `string` | `null` | no |
 | <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | (LC) Customize details about the root block device of the instance | `list(map(string))` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
       {
         "key"                 = "Name"
         "value"               = var.name
-        "propagate_at_launch" = true
+        "propagate_at_launch" = var.propagate_name
       },
     ],
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "tags_as_map" {
   default     = {}
 }
 
+variable "propagate_name" {
+  description = "Determines whether to propagate the ASG Name tag or not"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Common - launch configuration or launch template
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a variable to control the `propagate_at_launch` field of the `Name` tag added by the module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When providing tags for the ASG, a `Name` tag is added by the module, with  `propagate_at_launch` set to `true`. 
This takes precedent over `tag_specifications`, meaning any instance launched by the ASG will have the same name as the ASG, and this cannot be overridden as described in https://github.com/terraform-aws-modules/terraform-aws-autoscaling/issues/144#issuecomment-828047102

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `complete` example project was applied and destroyed using Terraform 0.14.11