### PR TITLE
feat: add checkpoint_delay, checkpoint_percent to instance refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ module "asg" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
+      checkpoint_delay       = 600
+      checkpoint_percentages = [35, 70, 100]
+      instance_warmup        = 300
       min_healthy_percentage = 50
     }
     triggers = ["tag"]

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.53 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.53 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -388,6 +388,9 @@ module "complete_lt" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
+      checkpoint_delay       = 600
+      checkpoint_percentages = [35, 70, 100]
+      instance_warmup        = 300
       min_healthy_percentage = 50
     }
     triggers = ["tag"]
@@ -572,6 +575,9 @@ module "complete_lc" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
+      checkpoint_delay       = 600
+      checkpoint_percentages = [35, 70, 100]
+      instance_warmup        = 300
       min_healthy_percentage = 50
     }
     triggers = ["tag"]
@@ -665,6 +671,9 @@ module "mixed_instance" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
+      checkpoint_delay       = 600
+      checkpoint_percentages = [35, 70, 100]
+      instance_warmup        = 300
       min_healthy_percentage = 50
     }
     triggers = ["tag"]

--- a/main.tf
+++ b/main.tf
@@ -376,6 +376,8 @@ resource "aws_autoscaling_group" "this" {
       dynamic "preferences" {
         for_each = lookup(instance_refresh.value, "preferences", null) != null ? [instance_refresh.value.preferences] : []
         content {
+          checkpoint_delay       = lookup(preferences.value, "checkpoint_delay", null)
+          checkpoint_percentages = lookup(preferences.value, "checkpoint_percentages", null)
           instance_warmup        = lookup(preferences.value, "instance_warmup", null)
           min_healthy_percentage = lookup(preferences.value, "min_healthy_percentage", null)
         }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.53"
+      version = ">= 3.64"
     }
 
     null = {


### PR DESCRIPTION
## Description
checkpoint_delay - (Optional) The number of seconds to wait after a checkpoint. Defaults to 3600.
checkpoint_percentages - (Optional) List of percentages for each checkpoint. Values must be unique and in ascending order. To replace all instances, the final number must be 100.

Parameter docs:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#preferences

## How Has This Been Tested?
- I have tested and validated these changes using one or more of the provided `examples/*` projects, triggered instance refresh by editing a tag and redeploying


