### PR TITLE
feat: add missing attributes to launch template, remove null resource for tag propagation, propagate default tags to instances, allow propagated name to be set independently of ASG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.56.0
+    rev: v1.57.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.57.0
+    rev: v1.58.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,8 @@
     [
       "@semantic-release/github",
       {
-        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version [${nextRelease.version}](${releaseInfos[0].url}) :tada:",
+        "successComment":
+        "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
         "labels": false,
         "releasedLabels": false
       }

--- a/README.md
+++ b/README.md
@@ -257,14 +257,12 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules
 
@@ -278,7 +276,7 @@ No modules.
 | [aws_autoscaling_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [null_resource.tags_as_list_of_maps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 
 ## Inputs
 
@@ -319,6 +317,7 @@ No modules.
 | <a name="input_initial_lifecycle_hooks"></a> [initial\_lifecycle\_hooks](#input\_initial\_lifecycle\_hooks) | One or more Lifecycle Hooks to attach to the Auto Scaling Group before instances are launched. The syntax is exactly the same as the separate `aws_autoscaling_lifecycle_hook` resource, without the `autoscaling_group_name` attribute. Please note that this will only work when creating a new Auto Scaling Group. For all other use-cases, please use `aws_autoscaling_lifecycle_hook` resource | `list(map(string))` | `[]` | no |
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | (LT) Shutdown behavior for the instance. Can be `stop` or `terminate`. (Default: `stop`) | `string` | `null` | no |
 | <a name="input_instance_market_options"></a> [instance\_market\_options](#input\_instance\_market\_options) | (LT) The market (purchasing) option for the instance | `any` | `null` | no |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name that is propogated to launched EC2 instances via a tag - if not provided, defaults to `var.name` | `string` | `""` | no |
 | <a name="input_instance_refresh"></a> [instance\_refresh](#input\_instance\_refresh) | If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated | `any` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance to launch | `string` | `""` | no |
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | (LT) The kernel ID | `string` | `null` | no |
@@ -344,7 +343,7 @@ No modules.
 | <a name="input_placement"></a> [placement](#input\_placement) | (LT) The placement of the instance | `map(string)` | `null` | no |
 | <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The name of the placement group into which you'll launch your instances, if any | `string` | `null` | no |
 | <a name="input_placement_tenancy"></a> [placement\_tenancy](#input\_placement\_tenancy) | (LC) The tenancy of the instance. Valid values are `default` or `dedicated` | `string` | `null` | no |
-| <a name="input_propagate_name"></a> [propagate\_name](#input\_propagate\_name) | Determines whether to propagate the ASG Name tag or not | `bool` | `true` | no |
+| <a name="input_propagate_name"></a> [propagate\_name](#input\_propagate\_name) | Determines whether to propagate the `var.instance_name`/`var.name` tag to launch instances | `bool` | `true` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | (LT) The ID of the ram disk | `string` | `null` | no |
 | <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | (LC) Customize details about the root block device of the instance | `list(map(string))` | `[]` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.44 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.44 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   region = local.region
 
+  default_tags {
+    tags = {
+      Project = "terraform-aws-autoscaling"
+    }
+  }
+
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
@@ -21,7 +27,7 @@ locals {
     },
     {
       key                 = "foo"
-      value               = ""
+      value               = "something"
       propagate_at_launch = true
     },
   ]
@@ -357,6 +363,7 @@ module "complete_lt" {
   # Autoscaling group
   name            = "complete-lt-${local.name}"
   use_name_prefix = false
+  instance_name   = "my-instance-name"
 
   min_size                  = 0
   max_size                  = 1
@@ -544,6 +551,7 @@ module "complete_lc" {
   # Autoscaling group
   name            = "complete-lc-${local.name}"
   use_name_prefix = false
+  instance_name   = "my-instance-name"
 
   min_size                  = 0
   max_size                  = 1

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.44"
+      version = ">= 3.64"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "aws_default_tags" "current" {}
+
 locals {
   lc_name              = coalesce(var.lc_name, var.name)
   launch_configuration = var.create_lc ? aws_launch_configuration.this[0].name : var.launch_configuration
@@ -6,27 +8,29 @@ locals {
   launch_template         = var.create_lt ? aws_launch_template.this[0].name : var.launch_template
   launch_template_version = var.create_lt && var.lt_version == null ? aws_launch_template.this[0].latest_version : var.lt_version
 
-  tags = concat(
+  tags = distinct(concat(
+    [for k, v in data.aws_default_tags.current.tags :
+      { key                 = v
+        value               = v
+        propagate_at_launch = true
+      }
+    ],
     [
       {
         key                 = "Name"
-        value               = var.name
+        value               = coalesce(var.instance_name, var.name)
         propagate_at_launch = var.propagate_name
       },
     ],
     var.tags,
-    null_resource.tags_as_list_of_maps.*.triggers,
-  )
-}
-
-resource "null_resource" "tags_as_list_of_maps" {
-  count = length(keys(var.tags_as_map))
-
-  triggers = {
-    key                 = keys(var.tags_as_map)[count.index]
-    value               = values(var.tags_as_map)[count.index]
-    propagate_at_launch = true
-  }
+    [for k, v in var.tags_as_map :
+      {
+        key                 = k
+        value               = v
+        propagate_at_launch = true
+      }
+    ]
+  ))
 }
 
 ################################################################################
@@ -225,7 +229,7 @@ resource "aws_launch_template" "this" {
       dynamic "spot_options" {
         for_each = lookup(instance_market_options.value, "spot_options", null) != null ? [instance_market_options.value.spot_options] : []
         content {
-          block_duration_minutes         = spot_options.value.block_duration_minutes
+          block_duration_minutes         = lookup(spot_options.value, "block_duration_minutes", null)
           instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
           max_price                      = lookup(spot_options.value, "max_price", null)
           spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)
@@ -248,6 +252,7 @@ resource "aws_launch_template" "this" {
       http_endpoint               = lookup(metadata_options.value, "http_endpoint", null)
       http_tokens                 = lookup(metadata_options.value, "http_tokens", null)
       http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", null)
+      http_protocol_ipv6          = lookup(metadata_options.value, "http_protocol_ipv6", null)
     }
   }
 
@@ -266,11 +271,13 @@ resource "aws_launch_template" "this" {
       delete_on_termination        = lookup(network_interfaces.value, "delete_on_termination", null)
       description                  = lookup(network_interfaces.value, "description", null)
       device_index                 = lookup(network_interfaces.value, "device_index", null)
+      interface_type               = lookup(network_interfaces.value, "interface_type", null)
       ipv4_addresses               = lookup(network_interfaces.value, "ipv4_addresses", null) != null ? network_interfaces.value.ipv4_addresses : []
       ipv4_address_count           = lookup(network_interfaces.value, "ipv4_address_count", null)
       ipv6_addresses               = lookup(network_interfaces.value, "ipv6_addresses", null) != null ? network_interfaces.value.ipv6_addresses : []
       ipv6_address_count           = lookup(network_interfaces.value, "ipv6_address_count", null)
       network_interface_id         = lookup(network_interfaces.value, "network_interface_id", null)
+      network_card_index           = lookup(network_interfaces.value, "network_card_index", null)
       private_ip_address           = lookup(network_interfaces.value, "private_ip_address", null)
       security_groups              = lookup(network_interfaces.value, "security_groups", null) != null ? network_interfaces.value.security_groups : []
       subnet_id                    = lookup(network_interfaces.value, "subnet_id", null)
@@ -280,13 +287,14 @@ resource "aws_launch_template" "this" {
   dynamic "placement" {
     for_each = var.placement != null ? [var.placement] : []
     content {
-      affinity          = lookup(placement.value, "affinity", null)
-      availability_zone = lookup(placement.value, "availability_zone", null)
-      group_name        = lookup(placement.value, "group_name", null)
-      host_id           = lookup(placement.value, "host_id", null)
-      spread_domain     = lookup(placement.value, "spread_domain", null)
-      tenancy           = lookup(placement.value, "tenancy", null)
-      partition_number  = lookup(placement.value, "partition_number", null)
+      affinity                = lookup(placement.value, "affinity", null)
+      availability_zone       = lookup(placement.value, "availability_zone", null)
+      group_name              = lookup(placement.value, "group_name", null)
+      host_id                 = lookup(placement.value, "host_id", null)
+      host_resource_group_arn = lookup(placement.value, "host_resource_group_arn", null)
+      spread_domain           = lookup(placement.value, "spread_domain", null)
+      tenancy                 = lookup(placement.value, "tenancy", null)
+      partition_number        = lookup(placement.value, "partition_number", null)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
 
   tags = distinct(concat(
     [for k, v in data.aws_default_tags.current.tags :
-      { key                 = v
+      { key                 = k
         value               = v
         propagate_at_launch = true
       }

--- a/outputs.tf
+++ b/outputs.tf
@@ -87,7 +87,7 @@ output "autoscaling_group_health_check_type" {
 
 output "autoscaling_group_availability_zones" {
   description = "The availability zones of the autoscale group"
-  value       = try(aws_autoscaling_group.this[0].availability_zones, "")
+  value       = try(aws_autoscaling_group.this[0].availability_zones, [""])
 }
 
 output "autoscaling_group_vpc_zone_identifier" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,17 +4,17 @@
 
 output "launch_configuration_id" {
   description = "The ID of the launch configuration"
-  value       = element(concat(aws_launch_configuration.this.*.id, [""]), 0)
+  value       = try(aws_launch_configuration.this[0].id, "")
 }
 
 output "launch_configuration_arn" {
   description = "The ARN of the launch configuration"
-  value       = element(concat(aws_launch_configuration.this.*.arn, [""]), 0)
+  value       = try(aws_launch_configuration.this[0].arn, "")
 }
 
 output "launch_configuration_name" {
   description = "The name of the launch configuration"
-  value       = element(concat(aws_launch_configuration.this.*.name, [""]), 0)
+  value       = try(aws_launch_configuration.this[0].name, "")
 }
 
 ################################################################################
@@ -23,17 +23,17 @@ output "launch_configuration_name" {
 
 output "launch_template_id" {
   description = "The ID of the launch template"
-  value       = element(concat(aws_launch_template.this.*.id, [""]), 0)
+  value       = try(aws_launch_template.this[0].id, "")
 }
 
 output "launch_template_arn" {
   description = "The ARN of the launch template"
-  value       = element(concat(aws_launch_template.this.*.arn, [""]), 0)
+  value       = try(aws_launch_template.this[0].arn, "")
 }
 
 output "launch_template_latest_version" {
   description = "The latest version of the launch template"
-  value       = element(concat(aws_launch_template.this.*.latest_version, [""]), 0)
+  value       = try(aws_launch_template.this[0].latest_version, "")
 }
 
 ################################################################################
@@ -42,67 +42,67 @@ output "launch_template_latest_version" {
 
 output "autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = element(concat(aws_autoscaling_group.this.*.id, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].id, "")
 }
 
 output "autoscaling_group_name" {
   description = "The autoscaling group name"
-  value       = element(concat(aws_autoscaling_group.this.*.name, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].name, "")
 }
 
 output "autoscaling_group_arn" {
   description = "The ARN for this AutoScaling Group"
-  value       = element(concat(aws_autoscaling_group.this.*.arn, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].arn, "")
 }
 
 output "autoscaling_group_min_size" {
   description = "The minimum size of the autoscale group"
-  value       = element(concat(aws_autoscaling_group.this.*.min_size, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].min_size, "")
 }
 
 output "autoscaling_group_max_size" {
   description = "The maximum size of the autoscale group"
-  value       = element(concat(aws_autoscaling_group.this.*.max_size, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].max_size, "")
 }
 
 output "autoscaling_group_desired_capacity" {
   description = "The number of Amazon EC2 instances that should be running in the group"
-  value       = element(concat(aws_autoscaling_group.this.*.desired_capacity, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].desired_capacity, "")
 }
 
 output "autoscaling_group_default_cooldown" {
   description = "Time between a scaling activity and the succeeding scaling activity"
-  value       = element(concat(aws_autoscaling_group.this.*.default_cooldown, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].default_cooldown, "")
 }
 
 output "autoscaling_group_health_check_grace_period" {
   description = "Time after instance comes into service before checking health"
-  value       = element(concat(aws_autoscaling_group.this.*.health_check_grace_period, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].health_check_grace_period, "")
 }
 
 output "autoscaling_group_health_check_type" {
   description = "EC2 or ELB. Controls how health checking is done"
-  value       = element(concat(aws_autoscaling_group.this.*.health_check_type, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].health_check_type, "")
 }
 
 output "autoscaling_group_availability_zones" {
   description = "The availability zones of the autoscale group"
-  value       = element(concat(aws_autoscaling_group.this.*.availability_zones, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].availability_zones, "")
 }
 
 output "autoscaling_group_vpc_zone_identifier" {
   description = "The VPC zone identifier"
-  value       = element(concat(aws_autoscaling_group.this.*.vpc_zone_identifier, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].vpc_zone_identifier, "")
 }
 
 output "autoscaling_group_load_balancers" {
   description = "The load balancer names associated with the autoscaling group"
-  value       = element(concat(aws_autoscaling_group.this.*.load_balancers, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].load_balancers, "")
 }
 
 output "autoscaling_group_target_group_arns" {
   description = "List of Target Group ARNs that apply to this AutoScaling Group"
-  value       = element(concat(aws_autoscaling_group.this.*.target_group_arns, [""]), 0)
+  value       = try(aws_autoscaling_group.this[0].target_group_arns, "")
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -87,7 +87,7 @@ output "autoscaling_group_health_check_type" {
 
 output "autoscaling_group_availability_zones" {
   description = "The availability zones of the autoscale group"
-  value       = try(aws_autoscaling_group.this[0].availability_zones, [""])
+  value       = try(aws_autoscaling_group.this[0].availability_zones, [])
 }
 
 output "autoscaling_group_vpc_zone_identifier" {
@@ -97,12 +97,12 @@ output "autoscaling_group_vpc_zone_identifier" {
 
 output "autoscaling_group_load_balancers" {
   description = "The load balancer names associated with the autoscaling group"
-  value       = try(aws_autoscaling_group.this[0].load_balancers, "")
+  value       = try(aws_autoscaling_group.this[0].load_balancers, [])
 }
 
 output "autoscaling_group_target_group_arns" {
   description = "List of Target Group ARNs that apply to this AutoScaling Group"
-  value       = try(aws_autoscaling_group.this[0].target_group_arns, "")
+  value       = try(aws_autoscaling_group.this[0].target_group_arns, [])
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,7 +92,7 @@ output "autoscaling_group_availability_zones" {
 
 output "autoscaling_group_vpc_zone_identifier" {
   description = "The VPC zone identifier"
-  value       = try(aws_autoscaling_group.this[0].vpc_zone_identifier, "")
+  value       = try(aws_autoscaling_group.this[0].vpc_zone_identifier, [])
 }
 
 output "autoscaling_group_load_balancers" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "use_name_prefix" {
   default     = true
 }
 
+variable "instance_name" {
+  description = "Name that is propogated to launched EC2 instances via a tag - if not provided, defaults to `var.name`"
+  type        = string
+  default     = ""
+}
+
 variable "launch_configuration" {
   description = "Name of an existing launch configuration to be used (created outside of this module)"
   type        = string
@@ -218,7 +224,7 @@ variable "tags_as_map" {
 }
 
 variable "propagate_name" {
-  description = "Determines whether to propagate the ASG Name tag or not"
+  description = "Determines whether to propagate the `var.instance_name`/`var.name` tag to launch instances"
   type        = bool
   default     = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.64"
     }
-
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## Description
- Add additional attributes that have been added to the launch template specification lately
- Remove the null resource for updating propagated tags; replace with a list comprehension expression that achieves the same result
- Add default tags data source and add in default tags to propagated tags: closes #162
- Add new variable `instance_name` that allows users to set the propagated instance name independently of the ASG `var.name`; if not specified it defaults to current `var.name`: closes #158
- Make the attribute `block_duration_minutes` option under `spot_options` - this is still supported in the AWS provider but by making this optional it will fix/close #156

## Motivation and Context
- Closes #156
- Closes #158
- Closes #162

## Breaking Changes
No, but users will see some updates in their plans with the switch from null resource to list comprehension of propagated tags

```hcl
# module.complete_lc.null_resource.tags_as_list_of_maps[0] will be destroyed
  - resource "null_resource" "tags_as_list_of_maps" {
      - id       = "4889299483352056787" -> null
      - triggers = {
          - "key"                 = "Environment"
          - "propagate_at_launch" = "true"
          - "value"               = "dev"
        } -> null
    }
```

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Launched `complete` example on `master` and switched to this branch and verified changes and diffs