### PR TITLE
feat: Add support for aws_autoscaling_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ No modules.
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The autoscaling group name |
 | <a name="output_autoscaling_group_target_group_arns"></a> [autoscaling\_group\_target\_group\_arns](#output\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_autoscaling_group_vpc_zone_identifier"></a> [autoscaling\_group\_vpc\_zone\_identifier](#output\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
-| <a name="output_autoscaling_policies"></a> [autoscaling\_policies](#output\_autoscaling\_policies) | ARNs of autoscaling policies |
+| <a name="output_autoscaling_policy_arns"></a> [autoscaling\_policy_arns](#output\_autoscaling\_policy_arns) | ARNs of autoscaling policies |
 | <a name="output_autoscaling_schedule_arns"></a> [autoscaling\_schedule\_arns](#output\_autoscaling\_schedule\_arns) | ARNs of autoscaling group schedules |
 | <a name="output_launch_configuration_arn"></a> [launch\_configuration\_arn](#output\_launch\_configuration\_arn) | The ARN of the launch configuration |
 | <a name="output_launch_configuration_id"></a> [launch\_configuration\_id](#output\_launch\_configuration\_id) | The ID of the launch configuration |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_autoscaling_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy) | resource |
 | [aws_autoscaling_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
 | [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -303,6 +304,7 @@ No modules.
 | <a name="input_create_asg"></a> [create\_asg](#input\_create\_asg) | Determines whether to create autoscaling group or not | `bool` | `true` | no |
 | <a name="input_create_lc"></a> [create\_lc](#input\_create\_lc) | Determines whether to create launch configuration or not | `bool` | `false` | no |
 | <a name="input_create_lt"></a> [create\_lt](#input\_create\_lt) | Determines whether to create launch template or not | `bool` | `false` | no |
+| <a name="input_create_scaling_policy"></a> [create\_scaling\_policy](#input\_create\_scaling\_policy) | Determines whether to create target scaling policy schedule or not | `bool` | `false` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |
 | <a name="input_credit_specification"></a> [credit\_specification](#input\_credit\_specification) | (LT) Customize the credit specification of the instance | `map(string)` | `null` | no |
 | <a name="input_default_cooldown"></a> [default\_cooldown](#input\_default\_cooldown) | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `null` | no |
@@ -359,6 +361,7 @@ No modules.
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | (LT) The ID of the ram disk | `string` | `null` | no |
 | <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | (LC) Customize details about the root block device of the instance | `list(map(string))` | `[]` | no |
+| <a name="input_scaling_policies"></a> [scaling\_policies](#input\_scaling\_policies) | Map of target scaling policy schedule to create | `map(any)` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to associate | `list(string)` | `null` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `null` | no |
@@ -398,6 +401,7 @@ No modules.
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The autoscaling group name |
 | <a name="output_autoscaling_group_target_group_arns"></a> [autoscaling\_group\_target\_group\_arns](#output\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_autoscaling_group_vpc_zone_identifier"></a> [autoscaling\_group\_vpc\_zone\_identifier](#output\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
+| <a name="output_autoscaling_policies"></a> [autoscaling\_policies](#output\_autoscaling\_policies) | ARNs of autoscaling policies |
 | <a name="output_autoscaling_schedule_arns"></a> [autoscaling\_schedule\_arns](#output\_autoscaling\_schedule\_arns) | ARNs of autoscaling group schedules |
 | <a name="output_launch_configuration_arn"></a> [launch\_configuration\_arn](#output\_launch\_configuration\_arn) | The ARN of the launch configuration |
 | <a name="output_launch_configuration_id"></a> [launch\_configuration\_id](#output\_launch\_configuration\_id) | The ID of the launch configuration |

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ No modules.
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | (LT) The ID of the ram disk | `string` | `null` | no |
 | <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | (LC) Customize details about the root block device of the instance | `list(map(string))` | `[]` | no |
-| <a name="input_scaling_policies"></a> [scaling\_policies](#input\_scaling\_policies) | Map of target scaling policy schedule to create | `map(any)` | `{}` | no |
+| <a name="input_scaling_policies"></a> [scaling\_policies](#input\_scaling\_policies) | Map of target scaling policy schedule to create | `any` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to associate | `list(string)` | `null` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `null` | no |
@@ -407,7 +407,7 @@ No modules.
 | <a name="output_autoscaling_group_name"></a> [autoscaling\_group\_name](#output\_autoscaling\_group\_name) | The autoscaling group name |
 | <a name="output_autoscaling_group_target_group_arns"></a> [autoscaling\_group\_target\_group\_arns](#output\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_autoscaling_group_vpc_zone_identifier"></a> [autoscaling\_group\_vpc\_zone\_identifier](#output\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
-| <a name="output_autoscaling_policy_arns"></a> [autoscaling\_policy_arns](#output\_autoscaling\_policy_arns) | ARNs of autoscaling policies |
+| <a name="output_autoscaling_policy_arns"></a> [autoscaling\_policy\_arns](#output\_autoscaling\_policy\_arns) | ARNs of autoscaling policies |
 | <a name="output_autoscaling_schedule_arns"></a> [autoscaling\_schedule\_arns](#output\_autoscaling\_schedule\_arns) | ARNs of autoscaling group schedules |
 | <a name="output_launch_configuration_arn"></a> [launch\_configuration\_arn](#output\_launch\_configuration\_arn) | The ARN of the launch configuration |
 | <a name="output_launch_configuration_id"></a> [launch\_configuration\_id](#output\_launch\_configuration\_id) | The ID of the launch configuration |

--- a/README.md
+++ b/README.md
@@ -226,10 +226,16 @@ The following combinations are supported to conditionally create resources and/o
 - Create the autoscaling policies:
 
 ```
-  create_scaling_policy = true
   scaling_policies = {
     my-policy = {
-      
+      policy_type               = "TargetTrackingScaling"
+      target_tracking_configuration = {
+        predefined_metric_specification = {
+          predefined_metric_type = "ASGAverageCPUUtilization"
+          resource_label         = "MyLabel"
+        }
+        target_value = 50.0
+      }
     }
   }
 ```
@@ -304,7 +310,7 @@ No modules.
 | <a name="input_create_asg"></a> [create\_asg](#input\_create\_asg) | Determines whether to create autoscaling group or not | `bool` | `true` | no |
 | <a name="input_create_lc"></a> [create\_lc](#input\_create\_lc) | Determines whether to create launch configuration or not | `bool` | `false` | no |
 | <a name="input_create_lt"></a> [create\_lt](#input\_create\_lt) | Determines whether to create launch template or not | `bool` | `false` | no |
-| <a name="input_create_scaling_policy"></a> [create\_scaling\_policy](#input\_create\_scaling\_policy) | Determines whether to create target scaling policy schedule or not | `bool` | `false` | no |
+| <a name="input_create_scaling_policy"></a> [create\_scaling\_policy](#input\_create\_scaling\_policy) | Determines whether to create target scaling policy schedule or not | `bool` | `true` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |
 | <a name="input_credit_specification"></a> [credit\_specification](#input\_credit\_specification) | (LT) Customize the credit specification of the instance | `map(string)` | `null` | no |
 | <a name="input_default_cooldown"></a> [default\_cooldown](#input\_default\_cooldown) | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Available features
 - Autoscaling group with launch template - either created by the module or utilizing an existing launch template
 - Autoscaling group utilizing mixed instances policy
 - Ability to configure autoscaling groups to set instance refresh configuration and add lifecycle hooks
+- Ability to configure autoscaling policies
 
 ## Usage
 
@@ -220,6 +221,17 @@ The following combinations are supported to conditionally create resources and/o
 ```hcl
   use_lt          = true
   launch_template = aws_launch_template.my_launch_template.name
+```
+
+- Create the autoscaling policies:
+
+```
+  create_scaling_policy = true
+  scaling_policies = {
+    my-policy = {
+      
+    }
+  }
 ```
 
 ## Tags

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -90,6 +90,7 @@ No inputs.
 | <a name="output_complete_lc_autoscaling_group_name"></a> [complete\_lc\_autoscaling\_group\_name](#output\_complete\_lc\_autoscaling\_group\_name) | The autoscaling group name |
 | <a name="output_complete_lc_autoscaling_group_target_group_arns"></a> [complete\_lc\_autoscaling\_group\_target\_group\_arns](#output\_complete\_lc\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_complete_lc_autoscaling_group_vpc_zone_identifier"></a> [complete\_lc\_autoscaling\_group\_vpc\_zone\_identifier](#output\_complete\_lc\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
+| <a name="output_complete_lc_autoscaling_policy_arns"></a> [complete\_lc\_autoscaling\_policy\_arns](#output\_complete\_lc\_autoscaling\_policy\_arns) | ARNs of autoscaling policies |
 | <a name="output_complete_lc_launch_configuration_arn"></a> [complete\_lc\_launch\_configuration\_arn](#output\_complete\_lc\_launch\_configuration\_arn) | The ARN of the launch configuration |
 | <a name="output_complete_lc_launch_configuration_id"></a> [complete\_lc\_launch\_configuration\_id](#output\_complete\_lc\_launch\_configuration\_id) | The ID of the launch configuration |
 | <a name="output_complete_lc_launch_configuration_name"></a> [complete\_lc\_launch\_configuration\_name](#output\_complete\_lc\_launch\_configuration\_name) | The name of the launch configuration |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -556,7 +556,7 @@ module "complete_lt" {
       }
     },
     predictive-scaling = {
-      policy_type            = "PredictiveScaling"
+      policy_type = "PredictiveScaling"
       predictive_scaling_config = {
         metric_specification = {
           target_value = 32

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -542,6 +542,20 @@ module "complete_lt" {
       end_time         = "2032-01-01T16:00:00Z"
     }
   }
+  # Target scaling policy schedule based on average CPU load
+  create_scaling_policy = true
+  scaling_policies = {
+    avg-cpu-policy-greater-than-50 = {
+      policy_type               = "TargetTrackingScaling"
+      estimated_instance_warmup = 1200
+      target_tracking_configuration = {
+        predefined_metric_specification = {
+          predefined_metric_type = "ASGAverageCPUUtilization"
+        }
+        target_value = 50.0
+      }
+    }
+  }
 }
 
 # Launch configuration

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -543,7 +543,6 @@ module "complete_lt" {
     }
   }
   # Target scaling policy schedule based on average CPU load
-  create_scaling_policy = true
   scaling_policies = {
     avg-cpu-policy-greater-than-50 = {
       policy_type               = "TargetTrackingScaling"
@@ -553,6 +552,26 @@ module "complete_lt" {
           predefined_metric_type = "ASGAverageCPUUtilization"
         }
         target_value = 50.0
+      }
+    },
+    predictive-scaling = {
+      policy_type            = "PredictiveScaling"
+      predictive_scaling_config = {
+        metric_specification = {
+          target_value = 32
+          predefined_scaling_metric_specification = {
+            predefined_metric_type = "ASGAverageCPUUtilization"
+            resource_label         = "testLabel"
+          }
+          predefined_load_metric_specification = {
+            predefined_metric_type = "ASGTotalCPUUtilization"
+            resource_label         = "testLabel"
+          }
+        }
+        mode                         = "ForecastAndScale"
+        scheduling_buffer_time       = 10
+        max_capacity_breach_behavior = "IncreaseMaxCapacity"
+        max_capacity_buffer          = 10
       }
     }
   }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -537,6 +537,11 @@ output "complete_lc_autoscaling_group_target_group_arns" {
   value       = module.complete_lc.autoscaling_group_target_group_arns
 }
 
+output "complete_lc_autoscaling_policy_arns" {
+  description = "ARNs of autoscaling policies"
+  value       = module.complete_lt.autoscaling_policy_arns
+}
+
 ################################################################################
 # Mixed instance policy
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -474,12 +474,12 @@ resource "aws_autoscaling_schedule" "this" {
 }
 
 ################################################################################
-# Target scaling policy schedule
+# Autoscaling Policy
 ################################################################################
 resource "aws_autoscaling_policy" "this" {
-  for_each = var.create_asg && var.create_scaling_policy ? var.scaling_policies : {}
+  for_each = { for k,v in var.scaling_policies : k => v if var.create_asg && var.create_scaling_policy }
 
-  name                      = each.key
+  name                      = lookup(each.value, "name", each.key)
   autoscaling_group_name    = aws_autoscaling_group.this[0].name
 
   adjustment_type           = lookup(each.value, "adjustment_type", null)

--- a/main.tf
+++ b/main.tf
@@ -477,10 +477,10 @@ resource "aws_autoscaling_schedule" "this" {
 # Autoscaling Policy
 ################################################################################
 resource "aws_autoscaling_policy" "this" {
-  for_each = { for k,v in var.scaling_policies : k => v if var.create_asg && var.create_scaling_policy }
+  for_each = { for k, v in var.scaling_policies : k => v if var.create_asg && var.create_scaling_policy }
 
-  name                      = lookup(each.value, "name", each.key)
-  autoscaling_group_name    = aws_autoscaling_group.this[0].name
+  name                   = lookup(each.value, "name", each.key)
+  autoscaling_group_name = aws_autoscaling_group.this[0].name
 
   adjustment_type           = lookup(each.value, "adjustment_type", null)
   policy_type               = lookup(each.value, "policy_type", null)
@@ -503,7 +503,7 @@ resource "aws_autoscaling_policy" "this" {
     content {
       target_value     = lookup(target_tracking_configuration.value, "target_value", null)
       disable_scale_in = lookup(target_tracking_configuration.value, "disable_scale_in", null)
-      
+
       dynamic "predefined_metric_specification" {
         for_each = lookup(target_tracking_configuration.value, "predefined_metric_specification", null) != null ? [target_tracking_configuration.value.predefined_metric_specification] : []
         content {
@@ -523,10 +523,10 @@ resource "aws_autoscaling_policy" "this" {
             }
           }
 
-          metric_name      = lookup(customized_metric_specification.value, "metric_name", null)
-          namespace        = lookup(customized_metric_specification.value, "namespace", null)
-          statistic        = lookup(customized_metric_specification.value, "statistic", null)
-          unit             = lookup(customized_metric_specification.value, "unit", null)
+          metric_name = lookup(customized_metric_specification.value, "metric_name", null)
+          namespace   = lookup(customized_metric_specification.value, "namespace", null)
+          statistic   = lookup(customized_metric_specification.value, "statistic", null)
+          unit        = lookup(customized_metric_specification.value, "unit", null)
         }
       }
     }
@@ -543,7 +543,7 @@ resource "aws_autoscaling_policy" "this" {
       dynamic "metric_specification" {
         for_each = lookup(predictive_scaling_configuration.value, "metric_specification", null) != null ? [predictive_scaling_configuration.value.metric_specification] : []
         content {
-          target_value     = lookup(metric_specification.value, "target_value", null)
+          target_value = lookup(metric_specification.value, "target_value", null)
 
           dynamic "predefined_load_metric_specification" {
             for_each = lookup(metric_specification.value, "predefined_load_metric_specification", null) != null ? [metric_specification.value.predefined_load_metric_specification] : []

--- a/main.tf
+++ b/main.tf
@@ -574,4 +574,3 @@ resource "aws_autoscaling_policy" "this" {
     }
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -472,3 +472,105 @@ resource "aws_autoscaling_schedule" "this" {
   # Cron examples: https://crontab.guru/examples.html
   recurrence = lookup(each.value, "recurrence", null)
 }
+
+################################################################################
+# Target scaling policy schedule
+################################################################################
+resource "aws_autoscaling_policy" "this" {
+  for_each = var.create_asg && var.create_scaling_policy ? var.scaling_policies : {}
+
+  name                      = each.key
+  autoscaling_group_name    = aws_autoscaling_group.this[0].name
+
+  adjustment_type           = lookup(each.value, "adjustment_type", null)
+  policy_type               = lookup(each.value, "policy_type", null)
+  estimated_instance_warmup = lookup(each.value, "estimated_instance_warmup", null)
+  cooldown                  = lookup(each.value, "cooldown", null)
+  min_adjustment_magnitude  = lookup(each.value, "min_adjustment_magnitude", null)
+  metric_aggregation_type   = lookup(each.value, "metric_aggregation_type", null)
+
+  dynamic "step_adjustment" {
+    for_each = lookup(each.value, "step_adjustment", null) != null ? [each.value.step_adjustment] : []
+    content {
+      scaling_adjustment          = lookup(step_adjustment.value, "scaling_adjustment", null)
+      metric_interval_lower_bound = lookup(step_adjustment.value, "metric_interval_lower_bound", null)
+      metric_interval_upper_bound = lookup(step_adjustment.value, "metric_interval_upper_bound", null)
+    }
+  }
+
+  dynamic "target_tracking_configuration" {
+    for_each = lookup(each.value, "target_tracking_configuration", null) != null ? [each.value.target_tracking_configuration] : []
+    content {
+      target_value     = lookup(target_tracking_configuration.value, "target_value", null)
+      disable_scale_in = lookup(target_tracking_configuration.value, "disable_scale_in", null)
+      
+      dynamic "predefined_metric_specification" {
+        for_each = lookup(target_tracking_configuration.value, "predefined_metric_specification", null) != null ? [target_tracking_configuration.value.predefined_metric_specification] : []
+        content {
+          predefined_metric_type = lookup(predefined_metric_specification.value, "predefined_metric_type", null)
+        }
+      }
+
+      dynamic "customized_metric_specification" {
+        for_each = lookup(target_tracking_configuration.value, "customized_metric_specification", null) != null ? [target_tracking_configuration.value.customized_metric_specification] : []
+        content {
+
+          dynamic "metric_dimension" {
+            for_each = lookup(customized_metric_specification.value, "metric_dimension", null) != null ? [customized_metric_specification.value.metric_dimension] : []
+            content {
+              name  = lookup(metric_dimension.value, "name", null)
+              value = lookup(metric_dimension.value, "value", null)
+            }
+          }
+
+          metric_name      = lookup(customized_metric_specification.value, "metric_name", null)
+          namespace        = lookup(customized_metric_specification.value, "namespace", null)
+          statistic        = lookup(customized_metric_specification.value, "statistic", null)
+          unit             = lookup(customized_metric_specification.value, "unit", null)
+        }
+      }
+    }
+  }
+
+  dynamic "predictive_scaling_configuration" {
+    for_each = lookup(each.value, "predictive_scaling_configuration", null) != null ? [each.value.predictive_scaling_configuration] : []
+    content {
+      max_capacity_breach_behavior = lookup(predictive_scaling_configuration.value, "max_capacity_breach_behavior", null)
+      max_capacity_buffer          = lookup(predictive_scaling_configuration.value, "max_capacity_buffer", null)
+      mode                         = lookup(predictive_scaling_configuration.value, "mode", null)
+      scheduling_buffer_time       = lookup(predictive_scaling_configuration.value, "scheduling_buffer_time", null)
+
+      dynamic "metric_specification" {
+        for_each = lookup(predictive_scaling_configuration.value, "metric_specification", null) != null ? [predictive_scaling_configuration.value.metric_specification] : []
+        content {
+          target_value     = lookup(metric_specification.value, "target_value", null)
+
+          dynamic "predefined_load_metric_specification" {
+            for_each = lookup(metric_specification.value, "predefined_load_metric_specification", null) != null ? [metric_specification.value.predefined_load_metric_specification] : []
+            content {
+              predefined_metric_type = lookup(predefined_load_metric_specification.value, "predefined_metric_type", null)
+              resource_label         = lookup(predefined_load_metric_specification.value, "resource_label", null)
+            }
+          }
+
+          dynamic "predefined_metric_pair_specification" {
+            for_each = lookup(metric_specification.value, "predefined_metric_pair_specification", null) != null ? [metric_specification.value.predefined_metric_pair_specification] : []
+            content {
+              predefined_metric_type = lookup(predefined_metric_pair_specification.value, "predefined_metric_type", null)
+              resource_label         = lookup(predefined_metric_pair_specification.value, "resource_label", null)
+            }
+          }
+
+          dynamic "predefined_scaling_metric_specification" {
+            for_each = lookup(metric_specification.value, "predefined_scaling_metric_specification", null) != null ? [metric_specification.value.predefined_scaling_metric_specification] : []
+            content {
+              predefined_metric_type = lookup(predefined_scaling_metric_specification.value, "predefined_metric_type", null)
+              resource_label         = lookup(predefined_scaling_metric_specification.value, "resource_label", null)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -492,7 +492,7 @@ resource "aws_autoscaling_policy" "this" {
   dynamic "step_adjustment" {
     for_each = lookup(each.value, "step_adjustment", null) != null ? [each.value.step_adjustment] : []
     content {
-      scaling_adjustment          = lookup(step_adjustment.value, "scaling_adjustment", null)
+      scaling_adjustment          = step_adjustment.value.scaling_adjustment
       metric_interval_lower_bound = lookup(step_adjustment.value, "metric_interval_lower_bound", null)
       metric_interval_upper_bound = lookup(step_adjustment.value, "metric_interval_upper_bound", null)
     }
@@ -501,13 +501,13 @@ resource "aws_autoscaling_policy" "this" {
   dynamic "target_tracking_configuration" {
     for_each = lookup(each.value, "target_tracking_configuration", null) != null ? [each.value.target_tracking_configuration] : []
     content {
-      target_value     = lookup(target_tracking_configuration.value, "target_value", null)
+      target_value     = target_tracking_configuration.value.target_value
       disable_scale_in = lookup(target_tracking_configuration.value, "disable_scale_in", null)
 
       dynamic "predefined_metric_specification" {
         for_each = lookup(target_tracking_configuration.value, "predefined_metric_specification", null) != null ? [target_tracking_configuration.value.predefined_metric_specification] : []
         content {
-          predefined_metric_type = lookup(predefined_metric_specification.value, "predefined_metric_type", null)
+          predefined_metric_type = predefined_metric_specification.value.predefined_metric_type
         }
       }
 
@@ -523,9 +523,9 @@ resource "aws_autoscaling_policy" "this" {
             }
           }
 
-          metric_name = lookup(customized_metric_specification.value, "metric_name", null)
-          namespace   = lookup(customized_metric_specification.value, "namespace", null)
-          statistic   = lookup(customized_metric_specification.value, "statistic", null)
+          metric_name = customized_metric_specification.value.metric_name
+          namespace   = customized_metric_specification.value.namespace
+          statistic   = customized_metric_specification.value.statistic
           unit        = lookup(customized_metric_specification.value, "unit", null)
         }
       }
@@ -541,31 +541,31 @@ resource "aws_autoscaling_policy" "this" {
       scheduling_buffer_time       = lookup(predictive_scaling_configuration.value, "scheduling_buffer_time", null)
 
       dynamic "metric_specification" {
-        for_each = lookup(predictive_scaling_configuration.value, "metric_specification", null) != null ? [predictive_scaling_configuration.value.metric_specification] : []
+        for_each = lookup(predictive_scaling_configuration.value, "metric_specification", [])
         content {
-          target_value = lookup(metric_specification.value, "target_value", null)
+          target_value = metric_specification.value.target_value
 
           dynamic "predefined_load_metric_specification" {
             for_each = lookup(metric_specification.value, "predefined_load_metric_specification", null) != null ? [metric_specification.value.predefined_load_metric_specification] : []
             content {
-              predefined_metric_type = lookup(predefined_load_metric_specification.value, "predefined_metric_type", null)
-              resource_label         = lookup(predefined_load_metric_specification.value, "resource_label", null)
+              predefined_metric_type = predefined_load_metric_specification.value.predefined_metric_type
+              resource_label         = predefined_load_metric_specification.value.resource_label
             }
           }
 
           dynamic "predefined_metric_pair_specification" {
             for_each = lookup(metric_specification.value, "predefined_metric_pair_specification", null) != null ? [metric_specification.value.predefined_metric_pair_specification] : []
             content {
-              predefined_metric_type = lookup(predefined_metric_pair_specification.value, "predefined_metric_type", null)
-              resource_label         = lookup(predefined_metric_pair_specification.value, "resource_label", null)
+              predefined_metric_type = predefined_metric_pair_specification.value.predefined_metric_type
+              resource_label         = predefined_metric_pair_specification.value.resource_label
             }
           }
 
           dynamic "predefined_scaling_metric_specification" {
             for_each = lookup(metric_specification.value, "predefined_scaling_metric_specification", null) != null ? [metric_specification.value.predefined_scaling_metric_specification] : []
             content {
-              predefined_metric_type = lookup(predefined_scaling_metric_specification.value, "predefined_metric_type", null)
-              resource_label         = lookup(predefined_scaling_metric_specification.value, "resource_label", null)
+              predefined_metric_type = predefined_scaling_metric_specification.value.predefined_metric_type
+              resource_label         = predefined_scaling_metric_specification.value.resource_label
             }
           }
         }

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,3 +113,13 @@ output "autoscaling_schedule_arns" {
   description = "ARNs of autoscaling group schedules"
   value       = { for k, v in aws_autoscaling_schedule.this : k => v.arn }
 }
+
+################################################################################
+# Target scaling policy schedule
+################################################################################
+
+output "autoscaling_schedule_arns" {
+  description = "ARNs of target scaling policy schedules"
+  value       = { for k, v in aws_autoscaling_policy.this : k => v.arn }
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -115,11 +115,11 @@ output "autoscaling_schedule_arns" {
 }
 
 ################################################################################
-# Target scaling policy schedule
+# Autoscaling Policy
 ################################################################################
 
-output "autoscaling_schedule_arns" {
-  description = "ARNs of target scaling policy schedules"
-  value       = { for k, v in aws_autoscaling_policy.this : k => v.arn }
+output "autoscaling_policies" {
+  description = "ARNs of autoscaling policies"
+  value       = aws_autoscaling_policy.this
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -118,7 +118,7 @@ output "autoscaling_schedule_arns" {
 # Autoscaling Policy
 ################################################################################
 
-output "autoscaling_policies" {
+output "autoscaling_policy_arns" {
   description = "ARNs of autoscaling policies"
   value       = { for k, v in aws_autoscaling_policy.this : k => v.arn }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -122,4 +122,3 @@ output "autoscaling_policies" {
   description = "ARNs of autoscaling policies"
   value       = aws_autoscaling_policy.this
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -120,5 +120,5 @@ output "autoscaling_schedule_arns" {
 
 output "autoscaling_policies" {
   description = "ARNs of autoscaling policies"
-  value       = aws_autoscaling_policy.this
+  value       = { for k, v in aws_autoscaling_policy.this : k => v.arn }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -549,4 +549,3 @@ variable "scaling_policies" {
   type        = map(any)
   default     = {}
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -535,7 +535,7 @@ variable "schedules" {
 
 
 ################################################################################
-# Target scaling policy schedule
+# Autoscaling policy
 ################################################################################
 
 variable "create_scaling_policy" {
@@ -546,6 +546,6 @@ variable "create_scaling_policy" {
 
 variable "scaling_policies" {
   description = "Map of target scaling policy schedule to create"
-  type        = map(any)
+  type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -541,7 +541,7 @@ variable "schedules" {
 variable "create_scaling_policy" {
   description = "Determines whether to create target scaling policy schedule or not"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "scaling_policies" {

--- a/variables.tf
+++ b/variables.tf
@@ -532,3 +532,21 @@ variable "schedules" {
   type        = map(any)
   default     = {}
 }
+
+
+################################################################################
+# Target scaling policy schedule
+################################################################################
+
+variable "create_scaling_policy" {
+  description = "Determines whether to create target scaling policy schedule or not"
+  type        = bool
+  default     = false
+}
+
+variable "scaling_policies" {
+  description = "Map of target scaling policy schedule to create"
+  type        = map(any)
+  default     = {}
+}
+


### PR DESCRIPTION
## Description
This PR adds support for aws_autoscaling_policy resource

Support is fully complete and covers all settings mentioned in documentation(https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy)

## Motivation and Context
I decided to implement support for this resource, as it's a part of ASGs, brings (important in my opinion) feature to scale-in / scale out based on CPU load metric (predefined_metric_type = ASGAverageCPUUtilization)

## How Has This Been Tested?
- [ *] I have tested and validated these changes using one or more of the provided `examples/*` projects
I tested this PR creating ASG with addition of following block of code:
```
  create_scaling_policy = true
  scaling_policies = {
    was-avg-cpu-policy-greater-than-xx = {
      policy_type               = "TargetTrackingScaling"
      estimated_instance_warmup = 1200
      target_tracking_configuration = {
        predefined_metric_specification = {
          predefined_metric_type = "ASGAverageCPUUtilization"
        }
        target_value = 50.0
      }
    }
  }
```
In `terraform plan` I see following result:
```
  # module.workers-ami-test.module.autoscaling.aws_autoscaling_policy.this["was-avg-cpu-policy-greater-than-xx"] will be created"aws_autoscaling_policy" "this" {
      + arn                       = (known after apply)
      + autoscaling_group_name    = "workers-ami-test"
      + estimated_instance_warmup = 1200
      + id                        = (known after apply)
      + metric_aggregation_type   = (known after apply)
      + name                      = "was-avg-cpu-policy-greater-than-xx"
      + policy_type               = "TargetTrackingScaling"

      + target_tracking_configuration {
          + disable_scale_in = false
          + target_value     = 50

          + predefined_metric_specification {
              + predefined_metric_type = "ASGAverageCPUUtilization"
            }
        }
    }
```
I also made a test without it, as variables have default value of `false` and `null`, it does not break anything