### PR TITLE
fix: Issue with aws_autoscaling_policy SimpleScaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -546,6 +546,7 @@ resource "aws_autoscaling_policy" "this" {
   cooldown                  = lookup(each.value, "cooldown", null)
   min_adjustment_magnitude  = lookup(each.value, "min_adjustment_magnitude", null)
   metric_aggregation_type   = lookup(each.value, "metric_aggregation_type", null)
+  scaling_adjustment        = lookup(each.value, "scaling_adjustment", null)
 
   dynamic "step_adjustment" {
     for_each = try([each.value.step_adjustment], [])


### PR DESCRIPTION
## Description
We currently create a new module for creating a new ECS cluster in AWS. When we set the autoscaling group, we found one problem with `aws_autoscaling_policy`. We need to create a SimpleScaling policy. When that, we receive a terraform error.

## Motivation and Context
Create a new autoscalling group with scalling_policies like use SimpleScaling policy type.

### Code Snippet to Reproduce
```
### scaling_policies 
  scaling_policies = {
    cpu_high = {
      adjustment_type    = "ChangeInCapacity"
      policy_type        = "SimpleScaling"
      cooldown           = "300"
      scaling_adjustment = "1"
    },
    cpu_low = {
      adjustment_type    = "ChangeInCapacity"
      policy_type        = "SimpleScaling"
      cooldown           = "300"
      scaling_adjustment = "-1"
    }
  }
```

### Terminal Output Screenshot(s)
``` shell
module.asg.aws_autoscaling_policy.this["cpu_high"]: Creating...
╷
│ Error: scaling_adjustment is required for policy type SimpleScaling
│ 
│   with module.asg.aws_autoscaling_policy.this["cpu_high"],
│   on ../../modules/AWS/terraform-aws-autoscaling/main.tf line 537, in resource "aws_autoscaling_policy" "this":
│  537: resource "aws_autoscaling_policy" "this" {
│ 
╵
ERRO[0015] 1 error occurred:
	* exit status 1
```
