### PR TITLE
chore: Fixed tags in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,24 +147,11 @@ module "asg" {
       tags          = { WhatAmI = "SpotInstanceRequest" }
     }
   ]
-
-  tags = [
-    {
-      key                 = "Environment"
-      value               = "dev"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Project"
-      value               = "megasecret"
-      propagate_at_launch = true
-    },
-  ]
-
-  tags_as_map = {
-    extra_tag1 = "extra_value1"
-    extra_tag2 = "extra_value2"
+  tags = {
+    Environment = "dev"
+    Project     = "megasecret"
   }
+
 }
 ```
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Example is either outdated or wrong


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
variables.tf has
```terraform
variable "tags" {
  description = "A map of tags to assign to resources"
  type        = map(string)
  default     = {}
}
```

there is no tags_as_map.

Let's adjust this info


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
no tests required