### PR TITLE
feat!: Update provider to `v4.x`, add new attributes from `v4.x`, change `user_data_base64` to `user_data`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.64.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -238,13 +238,13 @@ There are two ways to specify tags for auto-scaling group in this module - `tags
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
 
 ## Modules
 
@@ -268,37 +268,37 @@ No modules.
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier` | `list(string)` | `null` | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | `list(any)` | `[]` | no |
 | <a name="input_capacity_rebalance"></a> [capacity\_rebalance](#input\_capacity\_rebalance) | Indicates whether capacity rebalance is enabled | `bool` | `null` | no |
-| <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Targeting for EC2 capacity reservations | `any` | `null` | no |
-| <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | The CPU options for the instance | `map(string)` | `null` | no |
+| <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Targeting for EC2 capacity reservations | `any` | `{}` | no |
+| <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | The CPU options for the instance | `map(string)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether to create autoscaling group or not | `bool` | `true` | no |
 | <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | Determines whether to create launch template or not | `bool` | `true` | no |
 | <a name="input_create_scaling_policy"></a> [create\_scaling\_policy](#input\_create\_scaling\_policy) | Determines whether to create target scaling policy schedule or not | `bool` | `true` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |
-| <a name="input_credit_specification"></a> [credit\_specification](#input\_credit\_specification) | Customize the credit specification of the instance | `map(string)` | `null` | no |
+| <a name="input_credit_specification"></a> [credit\_specification](#input\_credit\_specification) | Customize the credit specification of the instance | `map(string)` | `{}` | no |
 | <a name="input_default_cooldown"></a> [default\_cooldown](#input\_default\_cooldown) | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `null` | no |
 | <a name="input_default_version"></a> [default\_version](#input\_default\_version) | Default Version of the launch template | `string` | `null` | no |
 | <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | Delete timeout to wait for destroying autoscaling group | `string` | `null` | no |
 | <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the autoscaling group | `number` | `null` | no |
 | <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 instance termination protection | `bool` | `null` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |
-| <a name="input_elastic_gpu_specifications"></a> [elastic\_gpu\_specifications](#input\_elastic\_gpu\_specifications) | The elastic GPU to attach to the instance | `map(string)` | `null` | no |
-| <a name="input_elastic_inference_accelerator"></a> [elastic\_inference\_accelerator](#input\_elastic\_inference\_accelerator) | Configuration block containing an Elastic Inference Accelerator to attach to the instance | `map(string)` | `null` | no |
-| <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Enables/disables detailed monitoring | `bool` | `null` | no |
-| <a name="input_enabled_metrics"></a> [enabled\_metrics](#input\_enabled\_metrics) | A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances` | `list(string)` | `null` | no |
-| <a name="input_enclave_options"></a> [enclave\_options](#input\_enclave\_options) | Enable Nitro Enclaves on launched instances | `map(string)` | `null` | no |
+| <a name="input_elastic_gpu_specifications"></a> [elastic\_gpu\_specifications](#input\_elastic\_gpu\_specifications) | The elastic GPU to attach to the instance | `map(string)` | `{}` | no |
+| <a name="input_elastic_inference_accelerator"></a> [elastic\_inference\_accelerator](#input\_elastic\_inference\_accelerator) | Configuration block containing an Elastic Inference Accelerator to attach to the instance | `map(string)` | `{}` | no |
+| <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Enables/disables detailed monitoring | `bool` | `true` | no |
+| <a name="input_enabled_metrics"></a> [enabled\_metrics](#input\_enabled\_metrics) | A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances` | `list(string)` | `[]` | no |
+| <a name="input_enclave_options"></a> [enclave\_options](#input\_enclave\_options) | Enable Nitro Enclaves on launched instances | `map(string)` | `{}` | no |
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Allows deleting the Auto Scaling Group without waiting for all instances in the pool to terminate. You can force an Auto Scaling Group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling | `bool` | `null` | no |
 | <a name="input_health_check_grace_period"></a> [health\_check\_grace\_period](#input\_health\_check\_grace\_period) | Time (in seconds) after instance comes into service before checking health | `number` | `null` | no |
 | <a name="input_health_check_type"></a> [health\_check\_type](#input\_health\_check\_type) | `EC2` or `ELB`. Controls how health checking is done | `string` | `null` | no |
-| <a name="input_hibernation_options"></a> [hibernation\_options](#input\_hibernation\_options) | The hibernation options for the instance | `map(string)` | `null` | no |
+| <a name="input_hibernation_options"></a> [hibernation\_options](#input\_hibernation\_options) | The hibernation options for the instance | `map(string)` | `{}` | no |
 | <a name="input_iam_instance_profile_arn"></a> [iam\_instance\_profile\_arn](#input\_iam\_instance\_profile\_arn) | The IAM Instance Profile ARN to launch the instance with | `string` | `null` | no |
 | <a name="input_iam_instance_profile_name"></a> [iam\_instance\_profile\_name](#input\_iam\_instance\_profile\_name) | The name attribute of the IAM instance profile to associate with launched instances | `string` | `null` | no |
 | <a name="input_ignore_desired_capacity_changes"></a> [ignore\_desired\_capacity\_changes](#input\_ignore\_desired\_capacity\_changes) | Determines whether the `desired_capacity` value is ignored after initial apply. See README note for more details | `bool` | `false` | no |
 | <a name="input_image_id"></a> [image\_id](#input\_image\_id) | The AMI from which to launch the instance | `string` | `""` | no |
 | <a name="input_initial_lifecycle_hooks"></a> [initial\_lifecycle\_hooks](#input\_initial\_lifecycle\_hooks) | One or more Lifecycle Hooks to attach to the Auto Scaling Group before instances are launched. The syntax is exactly the same as the separate `aws_autoscaling_lifecycle_hook` resource, without the `autoscaling_group_name` attribute. Please note that this will only work when creating a new Auto Scaling Group. For all other use-cases, please use `aws_autoscaling_lifecycle_hook` resource | `list(map(string))` | `[]` | no |
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Can be `stop` or `terminate`. (Default: `stop`) | `string` | `null` | no |
-| <a name="input_instance_market_options"></a> [instance\_market\_options](#input\_instance\_market\_options) | The market (purchasing) option for the instance | `any` | `null` | no |
+| <a name="input_instance_market_options"></a> [instance\_market\_options](#input\_instance\_market\_options) | The market (purchasing) option for the instance | `any` | `{}` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name that is propogated to launched EC2 instances via a tag - if not provided, defaults to `var.name` | `string` | `""` | no |
-| <a name="input_instance_refresh"></a> [instance\_refresh](#input\_instance\_refresh) | If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated | `any` | `null` | no |
+| <a name="input_instance_refresh"></a> [instance\_refresh](#input\_instance\_refresh) | If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated | `any` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance to launch | `string` | `""` | no |
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | The kernel ID | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name that should be used for the instance | `string` | `null` | no |
@@ -307,39 +307,40 @@ No modules.
 | <a name="input_launch_template_name"></a> [launch\_template\_name](#input\_launch\_template\_name) | Name of launch template to be created | `string` | `""` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version. Can be version number, `$Latest`, or `$Default` | `string` | `null` | no |
-| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `null` | no |
+| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `{}` | no |
 | <a name="input_load_balancers"></a> [load\_balancers](#input\_load\_balancers) | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
 | <a name="input_max_instance_lifetime"></a> [max\_instance\_lifetime](#input\_max\_instance\_lifetime) | The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 86400 and 31536000 seconds | `number` | `null` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | The maximum size of the autoscaling group | `number` | `null` | no |
-| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options for the instance | `map(string)` | `null` | no |
+| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options for the instance | `map(string)` | `{}` | no |
 | <a name="input_metrics_granularity"></a> [metrics\_granularity](#input\_metrics\_granularity) | The granularity to associate with the metrics to collect. The only valid value is `1Minute` | `string` | `null` | no |
 | <a name="input_min_elb_capacity"></a> [min\_elb\_capacity](#input\_min\_elb\_capacity) | Setting this causes Terraform to wait for this number of instances to show up healthy in the ELB only on creation. Updates will not wait on ELB instance number changes | `number` | `null` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | The minimum size of the autoscaling group | `number` | `null` | no |
 | <a name="input_mixed_instances_policy"></a> [mixed\_instances\_policy](#input\_mixed\_instances\_policy) | Configuration block containing settings to define launch targets for Auto Scaling groups | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name used across the resources created | `string` | n/a | yes |
 | <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
-| <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `null` | no |
+| <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |
 | <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The name of the placement group into which you'll launch your instances, if any | `string` | `null` | no |
+| <a name="input_private_dns_name_options"></a> [private\_dns\_name\_options](#input\_private\_dns\_name\_options) | The options for the instance hostname. The default values are inherited from the subnet | `map(string)` | `{}` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_scaling_policies"></a> [scaling\_policies](#input\_scaling\_policies) | Map of target scaling policy schedule to create | `any` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
-| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to associate | `list(string)` | `null` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of security group IDs to associate | `list(string)` | `[]` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `null` | no |
-| <a name="input_suspended_processes"></a> [suspended\_processes](#input\_suspended\_processes) | A list of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly | `list(string)` | `null` | no |
+| <a name="input_suspended_processes"></a> [suspended\_processes](#input\_suspended\_processes) | A list of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly | `list(string)` | `[]` | no |
 | <a name="input_tag_specifications"></a> [tag\_specifications](#input\_tag\_specifications) | The tags to apply to the resources during launch | `list(any)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources | `map(string)` | `{}` | no |
 | <a name="input_target_group_arns"></a> [target\_group\_arns](#input\_target\_group\_arns) | A set of `aws_alb_target_group` ARNs, for use with Application or Network Load Balancing | `list(string)` | `[]` | no |
-| <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default` | `list(string)` | `null` | no |
+| <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default` | `list(string)` | `[]` | no |
 | <a name="input_update_default_version"></a> [update\_default\_version](#input\_update\_default\_version) | Whether to update Default Version each update. Conflicts with `default_version` | `string` | `null` | no |
 | <a name="input_use_mixed_instances_policy"></a> [use\_mixed\_instances\_policy](#input\_use\_mixed\_instances\_policy) | Determines whether to use a mixed instances policy in the autoscaling group or not | `bool` | `false` | no |
 | <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix | `bool` | `true` | no |
-| <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | The Base64-encoded user data to provide when launching the instance | `string` | `null` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The Base64-encoded user data to provide when launching the instance | `string` | `null` | no |
 | <a name="input_vpc_zone_identifier"></a> [vpc\_zone\_identifier](#input\_vpc\_zone\_identifier) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `null` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior. | `number` | `null` | no |
-| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group | `any` | `null` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,13 +28,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
 
 ## Modules
 
@@ -56,6 +56,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_capacity_reservation) | resource |
 | [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,140 +30,6 @@ locals {
 }
 
 ################################################################################
-# Supporting Resources
-################################################################################
-
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
-
-  name = local.name
-  cidr = "10.99.0.0/18"
-
-  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  public_subnets  = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
-  private_subnets = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
-
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = local.tags
-}
-
-module "asg_sg" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4.0"
-
-  name        = local.name
-  description = "A security group"
-  vpc_id      = module.vpc.vpc_id
-
-  computed_ingress_with_source_security_group_id = [
-    {
-      rule                     = "http-80-tcp"
-      source_security_group_id = module.alb_http_sg.security_group_id
-    }
-  ]
-  number_of_computed_ingress_with_source_security_group_id = 1
-
-  egress_rules = ["all-all"]
-
-  tags = local.tags
-}
-
-data "aws_ami" "amazon_linux" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name = "name"
-
-    values = [
-      "amzn-ami-hvm-*-x86_64-gp2",
-    ]
-  }
-}
-
-resource "aws_iam_service_linked_role" "autoscaling" {
-  aws_service_name = "autoscaling.amazonaws.com"
-  description      = "A service linked role for autoscaling"
-  custom_suffix    = local.name
-
-  # Sometimes good sleep is required to have some IAM resources created before they can be used
-  provisioner "local-exec" {
-    command = "sleep 10"
-  }
-}
-
-resource "aws_iam_instance_profile" "ssm" {
-  name = "complete-${local.name}"
-  role = aws_iam_role.ssm.name
-  tags = local.tags
-}
-
-resource "aws_iam_role" "ssm" {
-  name = "complete-${local.name}"
-  tags = local.tags
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Action = "sts:AssumeRole",
-        Principal = {
-          Service = "ec2.amazonaws.com"
-        },
-        Effect = "Allow",
-        Sid    = ""
-      }
-    ]
-  })
-}
-
-module "alb_http_sg" {
-  source  = "terraform-aws-modules/security-group/aws//modules/http-80"
-  version = "~> 4.0"
-
-  name        = "${local.name}-alb-http"
-  vpc_id      = module.vpc.vpc_id
-  description = "Security group for ${local.name}"
-
-  ingress_cidr_blocks = ["0.0.0.0/0"]
-
-  tags = local.tags
-}
-
-module "alb" {
-  source  = "terraform-aws-modules/alb/aws"
-  version = "~> 6.0"
-
-  name = local.name
-
-  vpc_id          = module.vpc.vpc_id
-  subnets         = module.vpc.public_subnets
-  security_groups = [module.alb_http_sg.security_group_id]
-
-  http_tcp_listeners = [
-    {
-      port               = 80
-      protocol           = "HTTP"
-      target_group_index = 0
-    }
-  ]
-
-  target_groups = [
-    {
-      name             = local.name
-      backend_protocol = "HTTP"
-      backend_port     = 80
-      target_type      = "instance"
-    },
-  ]
-
-  tags = local.tags
-}
-
-################################################################################
 # Disabled
 ################################################################################
 
@@ -310,7 +176,7 @@ module "complete" {
 
   image_id          = data.aws_ami.amazon_linux.id
   instance_type     = "t3.micro"
-  user_data_base64  = base64encode(local.user_data)
+  user_data         = base64encode(local.user_data)
   ebs_optimized     = true
   enable_monitoring = true
 
@@ -568,5 +434,153 @@ module "warm_pool" {
     max_group_prepared_capacity = 2
   }
 
+  capacity_reservation_specification = {
+    capacity_reservation_target = {
+      capacity_reservation_id = aws_ec2_capacity_reservation.targeted.id
+    }
+  }
+
   tags = local.tags
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = "10.99.0.0/18"
+
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  public_subnets  = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = local.tags
+}
+
+module "asg_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = local.name
+  description = "A security group"
+  vpc_id      = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "http-80-tcp"
+      source_security_group_id = module.alb_http_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+
+  egress_rules = ["all-all"]
+
+  tags = local.tags
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+}
+
+resource "aws_iam_service_linked_role" "autoscaling" {
+  aws_service_name = "autoscaling.amazonaws.com"
+  description      = "A service linked role for autoscaling"
+  custom_suffix    = local.name
+
+  # Sometimes good sleep is required to have some IAM resources created before they can be used
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+}
+
+resource "aws_iam_instance_profile" "ssm" {
+  name = "complete-${local.name}"
+  role = aws_iam_role.ssm.name
+  tags = local.tags
+}
+
+resource "aws_iam_role" "ssm" {
+  name = "complete-${local.name}"
+  tags = local.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+        Effect = "Allow",
+        Sid    = ""
+      }
+    ]
+  })
+}
+
+module "alb_http_sg" {
+  source  = "terraform-aws-modules/security-group/aws//modules/http-80"
+  version = "~> 4.0"
+
+  name        = "${local.name}-alb-http"
+  vpc_id      = module.vpc.vpc_id
+  description = "Security group for ${local.name}"
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+
+  tags = local.tags
+}
+
+module "alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 6.0"
+
+  name = local.name
+
+  vpc_id          = module.vpc.vpc_id
+  subnets         = module.vpc.public_subnets
+  security_groups = [module.alb_http_sg.security_group_id]
+
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "HTTP"
+      target_group_index = 0
+    }
+  ]
+
+  target_groups = [
+    {
+      name             = local.name
+      backend_protocol = "HTTP"
+      backend_port     = 80
+      target_type      = "instance"
+    },
+  ]
+
+  tags = local.tags
+}
+
+resource "aws_ec2_capacity_reservation" "targeted" {
+  instance_type           = "t3.micro"
+  instance_platform       = "Linux/UNIX"
+  availability_zone       = "${local.region}a"
+  instance_count          = 1
+  instance_match_criteria = "targeted"
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.7"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -576,6 +576,7 @@ resource "aws_autoscaling_policy" "this" {
   cooldown                  = try(each.value.cooldown, null)
   min_adjustment_magnitude  = try(each.value.min_adjustment_magnitude, null)
   metric_aggregation_type   = try(each.value.metric_aggregation_type, null)
+  scaling_adjustment        = try(each.value.scaling_adjustment, null)
 
   dynamic "step_adjustment" {
     for_each = try([each.value.step_adjustment], [])

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_launch_template" "this" {
   image_id      = var.image_id
   instance_type = var.instance_type
   key_name      = var.key_name
-  user_data     = var.user_data_base64
+  user_data     = var.user_data
 
   vpc_security_group_ids = var.security_groups
 
@@ -44,41 +44,42 @@ resource "aws_launch_template" "this" {
     for_each = var.block_device_mappings
     content {
       device_name  = block_device_mappings.value.device_name
-      no_device    = lookup(block_device_mappings.value, "no_device", null)
-      virtual_name = lookup(block_device_mappings.value, "virtual_name", null)
+      no_device    = try(block_device_mappings.value.no_device, null)
+      virtual_name = try(block_device_mappings.value.virtual_name, null)
 
       dynamic "ebs" {
-        for_each = flatten([lookup(block_device_mappings.value, "ebs", [])])
+        for_each = flatten([try(block_device_mappings.value.ebs, [])])
         content {
-          delete_on_termination = lookup(ebs.value, "delete_on_termination", null)
-          encrypted             = lookup(ebs.value, "encrypted", null)
-          kms_key_id            = lookup(ebs.value, "kms_key_id", null)
-          iops                  = lookup(ebs.value, "iops", null)
-          throughput            = lookup(ebs.value, "throughput", null)
-          snapshot_id           = lookup(ebs.value, "snapshot_id", null)
-          volume_size           = lookup(ebs.value, "volume_size", null)
-          volume_type           = lookup(ebs.value, "volume_type", null)
+          delete_on_termination = try(ebs.value.delete_on_termination, null)
+          encrypted             = try(ebs.value.encrypted, null)
+          kms_key_id            = try(ebs.value.kms_key_id, null)
+          iops                  = try(ebs.value.iops, null)
+          throughput            = try(ebs.value.throughput, null)
+          snapshot_id           = try(ebs.value.snapshot_id, null)
+          volume_size           = try(ebs.value.volume_size, null)
+          volume_type           = try(ebs.value.volume_type, null)
         }
       }
     }
   }
 
   dynamic "capacity_reservation_specification" {
-    for_each = var.capacity_reservation_specification != null ? [var.capacity_reservation_specification] : []
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
     content {
-      capacity_reservation_preference = lookup(capacity_reservation_specification.value, "capacity_reservation_preference", null)
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
 
       dynamic "capacity_reservation_target" {
-        for_each = lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
         content {
-          capacity_reservation_id = lookup(capacity_reservation_target.value, "capacity_reservation_id", null)
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
         }
       }
     }
   }
 
   dynamic "cpu_options" {
-    for_each = var.cpu_options != null ? [var.cpu_options] : []
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
     content {
       core_count       = cpu_options.value.core_count
       threads_per_core = cpu_options.value.threads_per_core
@@ -86,35 +87,35 @@ resource "aws_launch_template" "this" {
   }
 
   dynamic "credit_specification" {
-    for_each = var.credit_specification != null ? [var.credit_specification] : []
+    for_each = length(var.credit_specification) > 0 ? [var.credit_specification] : []
     content {
       cpu_credits = credit_specification.value.cpu_credits
     }
   }
 
   dynamic "elastic_gpu_specifications" {
-    for_each = var.elastic_gpu_specifications != null ? [var.elastic_gpu_specifications] : []
+    for_each = length(var.elastic_gpu_specifications) > 0 ? [var.elastic_gpu_specifications] : []
     content {
       type = elastic_gpu_specifications.value.type
     }
   }
 
   dynamic "elastic_inference_accelerator" {
-    for_each = var.elastic_inference_accelerator != null ? [var.elastic_inference_accelerator] : []
+    for_each = length(var.elastic_inference_accelerator) > 0 ? [var.elastic_inference_accelerator] : []
     content {
       type = elastic_inference_accelerator.value.type
     }
   }
 
   dynamic "enclave_options" {
-    for_each = var.enclave_options != null ? [var.enclave_options] : []
+    for_each = length(var.enclave_options) > 0 ? [var.enclave_options] : []
     content {
       enabled = enclave_options.value.enabled
     }
   }
 
   dynamic "hibernation_options" {
-    for_each = var.hibernation_options != null ? [var.hibernation_options] : []
+    for_each = length(var.hibernation_options) > 0 ? [var.hibernation_options] : []
     content {
       configured = hibernation_options.value.configured
     }
@@ -129,43 +130,43 @@ resource "aws_launch_template" "this" {
   }
 
   dynamic "instance_market_options" {
-    for_each = var.instance_market_options != null ? [var.instance_market_options] : []
+    for_each = length(var.instance_market_options) > 0 ? [var.instance_market_options] : []
     content {
       market_type = instance_market_options.value.market_type
 
       dynamic "spot_options" {
         for_each = try([instance_market_options.value.spot_options], [])
         content {
-          block_duration_minutes         = lookup(spot_options.value, "block_duration_minutes", null)
-          instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
-          max_price                      = lookup(spot_options.value, "max_price", null)
-          spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)
-          valid_until                    = lookup(spot_options.value, "valid_until", null)
+          block_duration_minutes         = try(spot_options.value.block_duration_minutes, null)
+          instance_interruption_behavior = try(spot_options.value.instance_interruption_behavior, null)
+          max_price                      = try(spot_options.value.max_price, null)
+          spot_instance_type             = try(spot_options.value.spot_instance_type, null)
+          valid_until                    = try(spot_options.value.valid_until, null)
         }
       }
     }
   }
 
   dynamic "license_specification" {
-    for_each = var.license_specifications != null ? [var.license_specifications] : []
+    for_each = length(var.license_specifications) > 0 ? [var.license_specifications] : []
     content {
       license_configuration_arn = license_specifications.value.license_configuration_arn
     }
   }
 
   dynamic "metadata_options" {
-    for_each = var.metadata_options != null ? [var.metadata_options] : []
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
     content {
-      http_endpoint               = lookup(metadata_options.value, "http_endpoint", null)
-      http_tokens                 = lookup(metadata_options.value, "http_tokens", null)
-      http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", null)
-      http_protocol_ipv6          = lookup(metadata_options.value, "http_protocol_ipv6", null)
-      instance_metadata_tags      = lookup(metadata_options.value, "instance_metadata_tags", null)
+      http_endpoint               = try(metadata_options.value.http_endpoint, null)
+      http_tokens                 = try(metadata_options.value.http_tokens, null)
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, null)
+      http_protocol_ipv6          = try(metadata_options.value.http_protocol_ipv6, null)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
     }
   }
 
   dynamic "monitoring" {
-    for_each = var.enable_monitoring != null ? [1] : []
+    for_each = var.enable_monitoring ? [1] : []
     content {
       enabled = var.enable_monitoring
     }
@@ -174,35 +175,48 @@ resource "aws_launch_template" "this" {
   dynamic "network_interfaces" {
     for_each = var.network_interfaces
     content {
-      associate_carrier_ip_address = lookup(network_interfaces.value, "associate_carrier_ip_address", null)
-      associate_public_ip_address  = lookup(network_interfaces.value, "associate_public_ip_address", null)
-      delete_on_termination        = lookup(network_interfaces.value, "delete_on_termination", null)
-      description                  = lookup(network_interfaces.value, "description", null)
-      device_index                 = lookup(network_interfaces.value, "device_index", null)
-      interface_type               = lookup(network_interfaces.value, "interface_type", null)
+      associate_carrier_ip_address = try(network_interfaces.value.associate_carrier_ip_address, null)
+      associate_public_ip_address  = try(network_interfaces.value.associate_public_ip_address, null)
+      delete_on_termination        = try(network_interfaces.value.delete_on_termination, null)
+      description                  = try(network_interfaces.value.description, null)
+      device_index                 = try(network_interfaces.value.device_index, null)
+      interface_type               = try(network_interfaces.value.interface_type, null)
+      ipv4_prefix_count            = try(network_interfaces.value.ipv4_prefix_count, null)
+      ipv4_prefixes                = try(network_interfaces.value.ipv4_prefixes, null)
       ipv4_addresses               = try(network_interfaces.value.ipv4_addresses, [])
-      ipv4_address_count           = lookup(network_interfaces.value, "ipv4_address_count", null)
+      ipv4_address_count           = try(network_interfaces.value.ipv4_address_count, null)
+      ipv6_prefix_count            = try(network_interfaces.value.ipv6_prefix_count, null)
+      ipv6_prefixes                = try(network_interfaces.value.ipv6_prefixes, [])
       ipv6_addresses               = try(network_interfaces.value.ipv6_addresses, [])
-      ipv6_address_count           = lookup(network_interfaces.value, "ipv6_address_count", null)
-      network_interface_id         = lookup(network_interfaces.value, "network_interface_id", null)
-      network_card_index           = lookup(network_interfaces.value, "network_card_index", null)
-      private_ip_address           = lookup(network_interfaces.value, "private_ip_address", null)
+      ipv6_address_count           = try(network_interfaces.value.ipv6_address_count, null)
+      network_interface_id         = try(network_interfaces.value.network_interface_id, null)
+      network_card_index           = try(network_interfaces.value.network_card_index, null)
+      private_ip_address           = try(network_interfaces.value.private_ip_address, null)
       security_groups              = try(network_interfaces.value.security_groups, [])
-      subnet_id                    = lookup(network_interfaces.value, "subnet_id", null)
+      subnet_id                    = try(network_interfaces.value.subnet_id, null)
     }
   }
 
   dynamic "placement" {
-    for_each = var.placement != null ? [var.placement] : []
+    for_each = length(var.placement) > 0 ? [var.placement] : []
     content {
-      affinity                = lookup(placement.value, "affinity", null)
-      availability_zone       = lookup(placement.value, "availability_zone", null)
-      group_name              = lookup(placement.value, "group_name", null)
-      host_id                 = lookup(placement.value, "host_id", null)
-      host_resource_group_arn = lookup(placement.value, "host_resource_group_arn", null)
-      spread_domain           = lookup(placement.value, "spread_domain", null)
-      tenancy                 = lookup(placement.value, "tenancy", null)
-      partition_number        = lookup(placement.value, "partition_number", null)
+      affinity                = try(placement.value.affinity, null)
+      availability_zone       = try(placement.value.availability_zone, null)
+      group_name              = try(placement.value.group_name, null)
+      host_id                 = try(placement.value.host_id, null)
+      host_resource_group_arn = try(placement.value.host_resource_group_arn, null)
+      spread_domain           = try(placement.value.spread_domain, null)
+      tenancy                 = try(placement.value.tenancy, null)
+      partition_number        = try(placement.value.partition_number, null)
+    }
+  }
+
+  dynamic "private_dns_name_options" {
+    for_each = length(var.private_dns_name_options) > 0 ? [var.private_dns_name_options] : []
+    content {
+      enable_resource_name_dns_aaaa_record = try(private_dns_name_options.value.enable_resource_name_dns_aaaa_record, null)
+      enable_resource_name_dns_a_record    = try(private_dns_name_options.value.enable_resource_name_dns_a_record, null)
+      hostname_type                        = private_dns_name_options.value.hostname_type
     }
   }
 
@@ -272,28 +286,28 @@ resource "aws_autoscaling_group" "this" {
     for_each = var.initial_lifecycle_hooks
     content {
       name                    = initial_lifecycle_hook.value.name
-      default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)
-      heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
+      default_result          = try(initial_lifecycle_hook.value.default_result, null)
+      heartbeat_timeout       = try(initial_lifecycle_hook.value.heartbeat_timeout, null)
       lifecycle_transition    = initial_lifecycle_hook.value.lifecycle_transition
-      notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
-      notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)
-      role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
+      notification_metadata   = try(initial_lifecycle_hook.value.notification_metadata, null)
+      notification_target_arn = try(initial_lifecycle_hook.value.notification_target_arn, null)
+      role_arn                = try(initial_lifecycle_hook.value.role_arn, null)
     }
   }
 
   dynamic "instance_refresh" {
-    for_each = var.instance_refresh != null ? [var.instance_refresh] : []
+    for_each = length(var.instance_refresh) > 0 ? [var.instance_refresh] : []
     content {
       strategy = instance_refresh.value.strategy
-      triggers = lookup(instance_refresh.value, "triggers", null)
+      triggers = try(instance_refresh.value.triggers, null)
 
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = lookup(preferences.value, "checkpoint_delay", null)
-          checkpoint_percentages = lookup(preferences.value, "checkpoint_percentages", null)
-          instance_warmup        = lookup(preferences.value, "instance_warmup", null)
-          min_healthy_percentage = lookup(preferences.value, "min_healthy_percentage", null)
+          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup        = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
         }
       }
     }
@@ -305,12 +319,12 @@ resource "aws_autoscaling_group" "this" {
       dynamic "instances_distribution" {
         for_each = try([mixed_instances_policy.value.instances_distribution], [])
         content {
-          on_demand_allocation_strategy            = lookup(instances_distribution.value, "on_demand_allocation_strategy", null)
-          on_demand_base_capacity                  = lookup(instances_distribution.value, "on_demand_base_capacity", null)
-          on_demand_percentage_above_base_capacity = lookup(instances_distribution.value, "on_demand_percentage_above_base_capacity", null)
-          spot_allocation_strategy                 = lookup(instances_distribution.value, "spot_allocation_strategy", null)
-          spot_instance_pools                      = lookup(instances_distribution.value, "spot_instance_pools", null)
-          spot_max_price                           = lookup(instances_distribution.value, "spot_max_price", null)
+          on_demand_allocation_strategy            = try(instances_distribution.value.on_demand_allocation_strategy, null)
+          on_demand_base_capacity                  = try(instances_distribution.value.on_demand_base_capacity, null)
+          on_demand_percentage_above_base_capacity = try(instances_distribution.value.on_demand_percentage_above_base_capacity, null)
+          spot_allocation_strategy                 = try(instances_distribution.value.spot_allocation_strategy, null)
+          spot_instance_pools                      = try(instances_distribution.value.spot_instance_pools, null)
+          spot_max_price                           = try(instances_distribution.value.spot_max_price, null)
         }
       }
 
@@ -323,13 +337,13 @@ resource "aws_autoscaling_group" "this" {
         dynamic "override" {
           for_each = try(mixed_instances_policy.value.override, [])
           content {
-            instance_type     = lookup(override.value, "instance_type", null)
-            weighted_capacity = lookup(override.value, "weighted_capacity", null)
+            instance_type     = try(override.value.instance_type, null)
+            weighted_capacity = try(override.value.weighted_capacity, null)
 
             dynamic "launch_template_specification" {
               for_each = try([override.value.launch_template_specification], [])
               content {
-                launch_template_id = lookup(launch_template_specification.value, "launch_template_id", null)
+                launch_template_id = try(launch_template_specification.value.launch_template_id, null)
               }
             }
           }
@@ -339,11 +353,18 @@ resource "aws_autoscaling_group" "this" {
   }
 
   dynamic "warm_pool" {
-    for_each = var.warm_pool != null ? [var.warm_pool] : []
+    for_each = length(var.warm_pool) > 0 ? [var.warm_pool] : []
     content {
-      pool_state                  = lookup(warm_pool.value, "pool_state", null)
-      min_size                    = lookup(warm_pool.value, "min_size", null)
-      max_group_prepared_capacity = lookup(warm_pool.value, "max_group_prepared_capacity", null)
+      pool_state                  = try(warm_pool.value.pool_state, null)
+      min_size                    = try(warm_pool.value.min_size, null)
+      max_group_prepared_capacity = try(warm_pool.value.max_group_prepared_capacity, null)
+
+      dynamic "instance_reuse_policy" {
+        for_each = try([warm_pool.value.instance_reuse_policy], [])
+        content {
+          reuse_on_scale_in = try(instance_reuse_policy.value.reuse_on_scale_in, null)
+        }
+      }
     }
   }
 
@@ -416,28 +437,28 @@ resource "aws_autoscaling_group" "idc" {
     for_each = var.initial_lifecycle_hooks
     content {
       name                    = initial_lifecycle_hook.value.name
-      default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)
-      heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
+      default_result          = try(initial_lifecycle_hook.value.default_result, null)
+      heartbeat_timeout       = try(initial_lifecycle_hook.value.heartbeat_timeout, null)
       lifecycle_transition    = initial_lifecycle_hook.value.lifecycle_transition
-      notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
-      notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)
-      role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
+      notification_metadata   = try(initial_lifecycle_hook.value.notification_metadata, null)
+      notification_target_arn = try(initial_lifecycle_hook.value.notification_target_arn, null)
+      role_arn                = try(initial_lifecycle_hook.value.role_arn, null)
     }
   }
 
   dynamic "instance_refresh" {
-    for_each = var.instance_refresh != null ? [var.instance_refresh] : []
+    for_each = length(var.instance_refresh) > 0 ? [var.instance_refresh] : []
     content {
       strategy = instance_refresh.value.strategy
-      triggers = lookup(instance_refresh.value, "triggers", null)
+      triggers = try(instance_refresh.value.triggers, null)
 
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = lookup(preferences.value, "checkpoint_delay", null)
-          checkpoint_percentages = lookup(preferences.value, "checkpoint_percentages", null)
-          instance_warmup        = lookup(preferences.value, "instance_warmup", null)
-          min_healthy_percentage = lookup(preferences.value, "min_healthy_percentage", null)
+          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup        = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
         }
       }
     }
@@ -449,12 +470,12 @@ resource "aws_autoscaling_group" "idc" {
       dynamic "instances_distribution" {
         for_each = try([mixed_instances_policy.value.instances_distribution], [])
         content {
-          on_demand_allocation_strategy            = lookup(instances_distribution.value, "on_demand_allocation_strategy", null)
-          on_demand_base_capacity                  = lookup(instances_distribution.value, "on_demand_base_capacity", null)
-          on_demand_percentage_above_base_capacity = lookup(instances_distribution.value, "on_demand_percentage_above_base_capacity", null)
-          spot_allocation_strategy                 = lookup(instances_distribution.value, "spot_allocation_strategy", null)
-          spot_instance_pools                      = lookup(instances_distribution.value, "spot_instance_pools", null)
-          spot_max_price                           = lookup(instances_distribution.value, "spot_max_price", null)
+          on_demand_allocation_strategy            = try(instances_distribution.value.on_demand_allocation_strategy, null)
+          on_demand_base_capacity                  = try(instances_distribution.value.on_demand_base_capacity, null)
+          on_demand_percentage_above_base_capacity = try(instances_distribution.value.on_demand_percentage_above_base_capacity, null)
+          spot_allocation_strategy                 = try(instances_distribution.value.spot_allocation_strategy, null)
+          spot_instance_pools                      = try(instances_distribution.value.spot_instance_pools, null)
+          spot_max_price                           = try(instances_distribution.value.spot_max_price, null)
         }
       }
 
@@ -465,15 +486,15 @@ resource "aws_autoscaling_group" "idc" {
         }
 
         dynamic "override" {
-          for_each = try([mixed_instances_policy.value.override], [])
+          for_each = try(mixed_instances_policy.value.override, [])
           content {
-            instance_type     = lookup(override.value, "instance_type", null)
-            weighted_capacity = lookup(override.value, "weighted_capacity", null)
+            instance_type     = try(override.value.instance_type, null)
+            weighted_capacity = try(override.value.weighted_capacity, null)
 
             dynamic "launch_template_specification" {
               for_each = try([override.value.launch_template_specification], [])
               content {
-                launch_template_id = lookup(launch_template_specification.value, "launch_template_id", null)
+                launch_template_id = try(launch_template_specification.value.launch_template_id, null)
               }
             }
           }
@@ -483,11 +504,18 @@ resource "aws_autoscaling_group" "idc" {
   }
 
   dynamic "warm_pool" {
-    for_each = var.warm_pool != null ? [var.warm_pool] : []
+    for_each = length(var.warm_pool) > 0 ? [var.warm_pool] : []
     content {
-      pool_state                  = lookup(warm_pool.value, "pool_state", null)
-      min_size                    = lookup(warm_pool.value, "min_size", null)
-      max_group_prepared_capacity = lookup(warm_pool.value, "max_group_prepared_capacity", null)
+      pool_state                  = try(warm_pool.value.pool_state, null)
+      min_size                    = try(warm_pool.value.min_size, null)
+      max_group_prepared_capacity = try(warm_pool.value.max_group_prepared_capacity, null)
+
+      dynamic "instance_reuse_policy" {
+        for_each = try([warm_pool.value.instance_reuse_policy], [])
+        content {
+          reuse_on_scale_in = try(instance_reuse_policy.value.reuse_on_scale_in, null)
+        }
+      }
     }
   }
 
@@ -520,16 +548,16 @@ resource "aws_autoscaling_schedule" "this" {
   scheduled_action_name  = each.key
   autoscaling_group_name = try(aws_autoscaling_group.this[0].name, aws_autoscaling_group.idc[0].name)
 
-  min_size         = lookup(each.value, "min_size", null)
-  max_size         = lookup(each.value, "max_size", null)
-  desired_capacity = lookup(each.value, "desired_capacity", null)
-  start_time       = lookup(each.value, "start_time", null)
-  end_time         = lookup(each.value, "end_time", null)
-  time_zone        = lookup(each.value, "time_zone", null)
+  min_size         = try(each.value.min_size, null)
+  max_size         = try(each.value.max_size, null)
+  desired_capacity = try(each.value.desired_capacity, null)
+  start_time       = try(each.value.start_time, null)
+  end_time         = try(each.value.end_time, null)
+  time_zone        = try(each.value.time_zone, null)
 
   # [Minute] [Hour] [Day_of_Month] [Month_of_Year] [Day_of_Week]
   # Cron examples: https://crontab.guru/examples.html
-  recurrence = lookup(each.value, "recurrence", null)
+  recurrence = try(each.value.recurrence, null)
 }
 
 ################################################################################
@@ -539,22 +567,22 @@ resource "aws_autoscaling_schedule" "this" {
 resource "aws_autoscaling_policy" "this" {
   for_each = { for k, v in var.scaling_policies : k => v if local.create && var.create_scaling_policy }
 
-  name                   = lookup(each.value, "name", each.key)
+  name                   = try(each.value.name, each.key)
   autoscaling_group_name = var.ignore_desired_capacity_changes ? aws_autoscaling_group.idc[0].name : aws_autoscaling_group.this[0].name
 
-  adjustment_type           = lookup(each.value, "adjustment_type", null)
-  policy_type               = lookup(each.value, "policy_type", null)
-  estimated_instance_warmup = lookup(each.value, "estimated_instance_warmup", null)
-  cooldown                  = lookup(each.value, "cooldown", null)
-  min_adjustment_magnitude  = lookup(each.value, "min_adjustment_magnitude", null)
-  metric_aggregation_type   = lookup(each.value, "metric_aggregation_type", null)
+  adjustment_type           = try(each.value.adjustment_type, null)
+  policy_type               = try(each.value.policy_type, null)
+  estimated_instance_warmup = try(each.value.estimated_instance_warmup, null)
+  cooldown                  = try(each.value.cooldown, null)
+  min_adjustment_magnitude  = try(each.value.min_adjustment_magnitude, null)
+  metric_aggregation_type   = try(each.value.metric_aggregation_type, null)
 
   dynamic "step_adjustment" {
     for_each = try([each.value.step_adjustment], [])
     content {
       scaling_adjustment          = step_adjustment.value.scaling_adjustment
-      metric_interval_lower_bound = lookup(step_adjustment.value, "metric_interval_lower_bound", null)
-      metric_interval_upper_bound = lookup(step_adjustment.value, "metric_interval_upper_bound", null)
+      metric_interval_lower_bound = try(step_adjustment.value.metric_interval_lower_bound, null)
+      metric_interval_upper_bound = try(step_adjustment.value.metric_interval_upper_bound, null)
     }
   }
 
@@ -562,7 +590,7 @@ resource "aws_autoscaling_policy" "this" {
     for_each = try([each.value.target_tracking_configuration], [])
     content {
       target_value     = target_tracking_configuration.value.target_value
-      disable_scale_in = lookup(target_tracking_configuration.value, "disable_scale_in", null)
+      disable_scale_in = try(target_tracking_configuration.value.disable_scale_in, null)
 
       dynamic "predefined_metric_specification" {
         for_each = try([target_tracking_configuration.value.predefined_metric_specification], [])
@@ -578,15 +606,15 @@ resource "aws_autoscaling_policy" "this" {
           dynamic "metric_dimension" {
             for_each = try([customized_metric_specification.value.metric_dimension], [])
             content {
-              name  = lookup(metric_dimension.value, "name", null)
-              value = lookup(metric_dimension.value, "value", null)
+              name  = try(metric_dimension.value.name, null)
+              value = try(metric_dimension.value.value, null)
             }
           }
 
           metric_name = customized_metric_specification.value.metric_name
           namespace   = customized_metric_specification.value.namespace
           statistic   = customized_metric_specification.value.statistic
-          unit        = lookup(customized_metric_specification.value, "unit", null)
+          unit        = try(customized_metric_specification.value.unit, null)
         }
       }
     }
@@ -595,10 +623,10 @@ resource "aws_autoscaling_policy" "this" {
   dynamic "predictive_scaling_configuration" {
     for_each = try([each.value.predictive_scaling_configuration], [])
     content {
-      max_capacity_breach_behavior = lookup(predictive_scaling_configuration.value, "max_capacity_breach_behavior", null)
-      max_capacity_buffer          = lookup(predictive_scaling_configuration.value, "max_capacity_buffer", null)
-      mode                         = lookup(predictive_scaling_configuration.value, "mode", null)
-      scheduling_buffer_time       = lookup(predictive_scaling_configuration.value, "scheduling_buffer_time", null)
+      max_capacity_breach_behavior = try(predictive_scaling_configuration.value.max_capacity_breach_behavior, null)
+      max_capacity_buffer          = try(predictive_scaling_configuration.value.max_capacity_buffer, null)
+      mode                         = try(predictive_scaling_configuration.value.mode, null)
+      scheduling_buffer_time       = try(predictive_scaling_configuration.value.scheduling_buffer_time, null)
 
       dynamic "metric_specification" {
         for_each = try([predictive_scaling_configuration.value.metric_specification], [])

--- a/variables.tf
+++ b/variables.tf
@@ -148,13 +148,13 @@ variable "force_delete" {
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default`"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "suspended_processes" {
   description = "A list of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "max_instance_lifetime" {
@@ -166,7 +166,7 @@ variable "max_instance_lifetime" {
 variable "enabled_metrics" {
   description = "A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances`"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "metrics_granularity" {
@@ -190,7 +190,7 @@ variable "initial_lifecycle_hooks" {
 variable "instance_refresh" {
   description = "If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated"
   type        = any
-  default     = null
+  default     = {}
 }
 
 variable "use_mixed_instances_policy" {
@@ -219,8 +219,8 @@ variable "tags" {
 
 variable "warm_pool" {
   description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group"
-  type        = any
-  default     = null
+  type        = map(string)
+  default     = {}
 }
 
 variable "ebs_optimized" {
@@ -253,7 +253,7 @@ variable "key_name" {
   default     = null
 }
 
-variable "user_data_base64" {
+variable "user_data" {
   description = "The Base64-encoded user data to provide when launching the instance"
   type        = string
   default     = null
@@ -262,19 +262,19 @@ variable "user_data_base64" {
 variable "security_groups" {
   description = "A list of security group IDs to associate"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "enable_monitoring" {
   description = "Enables/disables detailed monitoring"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "metadata_options" {
   description = "Customize the metadata options for the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 ################################################################################
@@ -350,43 +350,43 @@ variable "block_device_mappings" {
 variable "capacity_reservation_specification" {
   description = "Targeting for EC2 capacity reservations"
   type        = any
-  default     = null
+  default     = {}
 }
 
 variable "cpu_options" {
   description = "The CPU options for the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "credit_specification" {
   description = "Customize the credit specification of the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "elastic_gpu_specifications" {
   description = "The elastic GPU to attach to the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "elastic_inference_accelerator" {
   description = "Configuration block containing an Elastic Inference Accelerator to attach to the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "enclave_options" {
   description = "Enable Nitro Enclaves on launched instances"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "hibernation_options" {
   description = "The hibernation options for the instance"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "iam_instance_profile_arn" {
@@ -398,13 +398,13 @@ variable "iam_instance_profile_arn" {
 variable "instance_market_options" {
   description = "The market (purchasing) option for the instance"
   type        = any
-  default     = null
+  default     = {}
 }
 
 variable "license_specifications" {
   description = "A list of license specifications to associate with"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "network_interfaces" {
@@ -416,7 +416,13 @@ variable "network_interfaces" {
 variable "placement" {
   description = "The placement of the instance"
   type        = map(string)
-  default     = null
+  default     = {}
+}
+
+variable "private_dns_name_options" {
+  description = "The options for the instance hostname. The default values are inherited from the subnet"
+  type        = map(string)
+  default     = {}
 }
 
 variable "tag_specifications" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.7"
     }
   }
 }


### PR DESCRIPTION
## Description
- Update provider to `v4.x` to support attributes added
- Change `user_data_base64` to `user_data` to match resource name used
- Add `capacity_reservation_resource_group_arn` attribute to `capacity_reservation_specification.capacity_reservation_target`
- Add `ipv4_prefix_count`, `ipv4_prefixes`, `ipv6_prefix_count`, `ipv6_prefixes` to `network_interfaces`
- Add `private_dns_name_options` block and its attributes
- Add `instance_reuse_policy` block and its attributes to `warm_pool`

## Motivation and Context
- Updates module to use latest features offered in `v4.x` provider
- Variable name change made to align with resource name spec (was a legacy name that looks to have been missed in prior breaking change)
- Pulling this module up to be as current as possible before using in EKS module v19.x
	- This module will create the launch template and ASG for the EKS self managed node group, the launch template for the EKS managed node group, and probably add the option to create a launch template with user data rendered for use with [Karpenter](https://github.com/aws/karpenter) which handles cluster compute scaling using launch template). This will also give users of self managed node groups the ability to control desired size or not, which has been requested quite a bit
- Closes #183
- Closes #184

## Breaking Changes
- Yes; provider major version bump and one variable name change - no state manipulations required

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
