### PR TITLE
feat: Improved support for EFA network interfaces

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -9,6 +9,8 @@ There are primarily six different setups shown in this example project:
 - `external` - demonstrates how to create an autoscaling group using an externally created launch template
 - `complete` - demonstrates the vast majority of the functionality available for creating an autoscaling group
 - `mixed instance` - demonstrates how to create an autoscaling group configured to use a mixed instance policy
+- `warm pool` - demonstrates the usage of warm pools with capacity reservations
+- `efa` - demonstrates the usage of EFA (Elastic Fabric Adapter) type network interfaces
 
 ## Usage
 
@@ -46,6 +48,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_complete"></a> [complete](#module\_complete) | ../../ | n/a |
 | <a name="module_default"></a> [default](#module\_default) | ../../ | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
+| <a name="module_efa"></a> [efa](#module\_efa) | ../../ | n/a |
 | <a name="module_external"></a> [external](#module\_external) | ../../ | n/a |
 | <a name="module_launch_template_only"></a> [launch\_template\_only](#module\_launch\_template\_only) | ../../ | n/a |
 | <a name="module_mixed_instance"></a> [mixed\_instance](#module\_mixed\_instance) | ../../ | n/a |

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,8 @@ resource "aws_launch_template" "this" {
   key_name      = var.key_name
   user_data     = var.user_data
 
-  vpc_security_group_ids = var.security_groups
+  # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/4570
+  vpc_security_group_ids = length(var.network_interfaces) > 0 ? [] : var.security_groups
 
   default_version                      = var.default_version
   update_default_version               = var.update_default_version
@@ -192,8 +193,9 @@ resource "aws_launch_template" "this" {
       network_interface_id         = try(network_interfaces.value.network_interface_id, null)
       network_card_index           = try(network_interfaces.value.network_card_index, null)
       private_ip_address           = try(network_interfaces.value.private_ip_address, null)
-      security_groups              = try(network_interfaces.value.security_groups, [])
-      subnet_id                    = try(network_interfaces.value.subnet_id, null)
+      # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/4570
+      security_groups = compact(concat(try(network_interfaces.value.security_groups, []), var.security_groups))
+      subnet_id       = try(network_interfaces.value.subnet_id, null)
     }
   }
 


### PR DESCRIPTION
## Description
- Improved support for EFA network interfaces. Do to https://github.com/hashicorp/terraform-provider-aws/issues/4570, users cannot specify both `var.security_groups` and `var.network_interfaces`. Therefore, to make this issue seamless to users, when one or more network interface definition is provided, the `var.security_groups` are transparently moved down to the interface. Users can still provide additional security groups per interface if they desire

## Motivation and Context
- Relates to change made here https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1980

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Added a beefy, expensive example in `examples/complete`
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
