### PR TITLE
feat: Add separate autoscaling group tag variable, correct variable name for `availability_zones` to match resource spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier` | `list(string)` | `null` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier` | `list(string)` | `null` | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | `list(any)` | `[]` | no |
 | <a name="input_capacity_rebalance"></a> [capacity\_rebalance](#input\_capacity\_rebalance) | Indicates whether capacity rebalance is enabled | `bool` | `null` | no |
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Targeting for EC2 capacity reservations | `any` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | A map of additional tags to add to the autoscaling group | `map(string)` | `{}` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier` | `list(string)` | `null` | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | `list(any)` | `[]` | no |
 | <a name="input_capacity_rebalance"></a> [capacity\_rebalance](#input\_capacity\_rebalance) | Indicates whether capacity rebalance is enabled | `bool` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ locals {
     data.aws_default_tags.current.tags,
     var.tags,
     { "Name" = coalesce(var.instance_name, var.name) },
+    var.autoscaling_group_tags,
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
-  availability_zones  = var.availability_zone
+  availability_zones  = var.availability_zones
   vpc_zone_identifier = var.vpc_zone_identifier
 
   min_size                  = var.min_size
@@ -407,7 +407,7 @@ resource "aws_autoscaling_group" "idc" {
     }
   }
 
-  availability_zones  = var.availability_zone
+  availability_zones  = var.availability_zones
   vpc_zone_identifier = var.vpc_zone_identifier
 
   min_size                  = var.min_size

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "launch_template_version" {
   default     = null
 }
 
-variable "availability_zone" {
+variable "availability_zones" {
   description = "A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier`"
   type        = list(string)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -277,6 +277,12 @@ variable "metadata_options" {
   default     = {}
 }
 
+variable "autoscaling_group_tags" {
+  description = "A map of additional tags to add to the autoscaling group"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Launch template
 ################################################################################


### PR DESCRIPTION
## Description
- Correct variable name for `availability_zones` to match resource spec and denote that its more than one item
- Add new, separate variable for `autoscaling_group_tags` to add tags to just the autoscaling group

## Motivation and Context
- Looks like a typo - should have had the trailing `s`

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
