### PR TITLE
feat: Add outputs for launch template name and default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,10 @@ No modules.
 | <a name="output_autoscaling_policy_arns"></a> [autoscaling\_policy\_arns](#output\_autoscaling\_policy\_arns) | ARNs of autoscaling policies |
 | <a name="output_autoscaling_schedule_arns"></a> [autoscaling\_schedule\_arns](#output\_autoscaling\_schedule\_arns) | ARNs of autoscaling group schedules |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_launch_template_default_version"></a> [launch\_template\_default\_version](#output\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_launch_template_latest_version"></a> [launch\_template\_latest\_version](#output\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_launch_template_name"></a> [launch\_template\_name](#output\_launch\_template\_name) | The name of the launch template |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -90,8 +90,10 @@ No inputs.
 | <a name="output_complete_autoscaling_policy_arns"></a> [complete\_autoscaling\_policy\_arns](#output\_complete\_autoscaling\_policy\_arns) | ARNs of autoscaling policies |
 | <a name="output_complete_autoscaling_schedule_arns"></a> [complete\_autoscaling\_schedule\_arns](#output\_complete\_autoscaling\_schedule\_arns) | ARNs of autoscaling group schedules |
 | <a name="output_complete_launch_template_arn"></a> [complete\_launch\_template\_arn](#output\_complete\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_complete_launch_template_default_version"></a> [complete\_launch\_template\_default\_version](#output\_complete\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_complete_launch_template_id"></a> [complete\_launch\_template\_id](#output\_complete\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_complete_launch_template_latest_version"></a> [complete\_launch\_template\_latest\_version](#output\_complete\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_complete_launch_template_name"></a> [complete\_launch\_template\_name](#output\_complete\_launch\_template\_name) | The name of the launch template |
 | <a name="output_default_autoscaling_group_arn"></a> [default\_autoscaling\_group\_arn](#output\_default\_autoscaling\_group\_arn) | The ARN for this AutoScaling Group |
 | <a name="output_default_autoscaling_group_availability_zones"></a> [default\_autoscaling\_group\_availability\_zones](#output\_default\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_default_autoscaling_group_default_cooldown"></a> [default\_autoscaling\_group\_default\_cooldown](#output\_default\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
@@ -106,8 +108,10 @@ No inputs.
 | <a name="output_default_autoscaling_group_target_group_arns"></a> [default\_autoscaling\_group\_target\_group\_arns](#output\_default\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_default_autoscaling_group_vpc_zone_identifier"></a> [default\_autoscaling\_group\_vpc\_zone\_identifier](#output\_default\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
 | <a name="output_default_launch_template_arn"></a> [default\_launch\_template\_arn](#output\_default\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_default_launch_template_default_version"></a> [default\_launch\_template\_default\_version](#output\_default\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_default_launch_template_id"></a> [default\_launch\_template\_id](#output\_default\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_default_launch_template_latest_version"></a> [default\_launch\_template\_latest\_version](#output\_default\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_default_launch_template_name"></a> [default\_launch\_template\_name](#output\_default\_launch\_template\_name) | The name of the launch template |
 | <a name="output_external_autoscaling_group_arn"></a> [external\_autoscaling\_group\_arn](#output\_external\_autoscaling\_group\_arn) | The ARN for this AutoScaling Group |
 | <a name="output_external_autoscaling_group_availability_zones"></a> [external\_autoscaling\_group\_availability\_zones](#output\_external\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_external_autoscaling_group_default_cooldown"></a> [external\_autoscaling\_group\_default\_cooldown](#output\_external\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
@@ -122,11 +126,15 @@ No inputs.
 | <a name="output_external_autoscaling_group_target_group_arns"></a> [external\_autoscaling\_group\_target\_group\_arns](#output\_external\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_external_autoscaling_group_vpc_zone_identifier"></a> [external\_autoscaling\_group\_vpc\_zone\_identifier](#output\_external\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
 | <a name="output_external_launch_template_arn"></a> [external\_launch\_template\_arn](#output\_external\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_external_launch_template_default_version"></a> [external\_launch\_template\_default\_version](#output\_external\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_external_launch_template_id"></a> [external\_launch\_template\_id](#output\_external\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_external_launch_template_latest_version"></a> [external\_launch\_template\_latest\_version](#output\_external\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_external_launch_template_name"></a> [external\_launch\_template\_name](#output\_external\_launch\_template\_name) | The name of the launch template |
 | <a name="output_launch_template_only_launch_template_arn"></a> [launch\_template\_only\_launch\_template\_arn](#output\_launch\_template\_only\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_launch_template_only_launch_template_default_version"></a> [launch\_template\_only\_launch\_template\_default\_version](#output\_launch\_template\_only\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_launch_template_only_launch_template_id"></a> [launch\_template\_only\_launch\_template\_id](#output\_launch\_template\_only\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_launch_template_only_launch_template_latest_version"></a> [launch\_template\_only\_launch\_template\_latest\_version](#output\_launch\_template\_only\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_launch_template_only_launch_template_name"></a> [launch\_template\_only\_launch\_template\_name](#output\_launch\_template\_only\_launch\_template\_name) | The name of the launch template |
 | <a name="output_mixed_instance_autoscaling_group_arn"></a> [mixed\_instance\_autoscaling\_group\_arn](#output\_mixed\_instance\_autoscaling\_group\_arn) | The ARN for this AutoScaling Group |
 | <a name="output_mixed_instance_autoscaling_group_availability_zones"></a> [mixed\_instance\_autoscaling\_group\_availability\_zones](#output\_mixed\_instance\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_mixed_instance_autoscaling_group_default_cooldown"></a> [mixed\_instance\_autoscaling\_group\_default\_cooldown](#output\_mixed\_instance\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
@@ -141,6 +149,8 @@ No inputs.
 | <a name="output_mixed_instance_autoscaling_group_target_group_arns"></a> [mixed\_instance\_autoscaling\_group\_target\_group\_arns](#output\_mixed\_instance\_autoscaling\_group\_target\_group\_arns) | List of Target Group ARNs that apply to this AutoScaling Group |
 | <a name="output_mixed_instance_autoscaling_group_vpc_zone_identifier"></a> [mixed\_instance\_autoscaling\_group\_vpc\_zone\_identifier](#output\_mixed\_instance\_autoscaling\_group\_vpc\_zone\_identifier) | The VPC zone identifier |
 | <a name="output_mixed_instance_launch_template_arn"></a> [mixed\_instance\_launch\_template\_arn](#output\_mixed\_instance\_launch\_template\_arn) | The ARN of the launch template |
+| <a name="output_mixed_instance_launch_template_default_version"></a> [mixed\_instance\_launch\_template\_default\_version](#output\_mixed\_instance\_launch\_template\_default\_version) | The default version of the launch template |
 | <a name="output_mixed_instance_launch_template_id"></a> [mixed\_instance\_launch\_template\_id](#output\_mixed\_instance\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_mixed_instance_launch_template_latest_version"></a> [mixed\_instance\_launch\_template\_latest\_version](#output\_mixed\_instance\_launch\_template\_latest\_version) | The latest version of the launch template |
+| <a name="output_mixed_instance_launch_template_name"></a> [mixed\_instance\_launch\_template\_name](#output\_mixed\_instance\_launch\_template\_name) | The name of the launch template |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -12,9 +12,19 @@ output "launch_template_only_launch_template_arn" {
   value       = module.launch_template_only.launch_template_arn
 }
 
+output "launch_template_only_launch_template_name" {
+  description = "The name of the launch template"
+  value       = module.launch_template_only.launch_template_name
+}
+
 output "launch_template_only_launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = module.launch_template_only.launch_template_latest_version
+}
+
+output "launch_template_only_launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = module.launch_template_only.launch_template_default_version
 }
 
 ################################################################################
@@ -31,9 +41,19 @@ output "default_launch_template_arn" {
   value       = module.default.launch_template_arn
 }
 
+output "default_launch_template_name" {
+  description = "The name of the launch template"
+  value       = module.default.launch_template_name
+}
+
 output "default_launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = module.default.launch_template_latest_version
+}
+
+output "default_launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = module.default.launch_template_default_version
 }
 
 output "default_autoscaling_group_id" {
@@ -115,9 +135,19 @@ output "external_launch_template_arn" {
   value       = module.external.launch_template_arn
 }
 
+output "external_launch_template_name" {
+  description = "The name of the launch template"
+  value       = module.external.launch_template_name
+}
+
 output "external_launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = module.external.launch_template_latest_version
+}
+
+output "external_launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = module.external.launch_template_default_version
 }
 
 output "external_autoscaling_group_id" {
@@ -199,9 +229,19 @@ output "complete_launch_template_arn" {
   value       = module.complete.launch_template_arn
 }
 
+output "complete_launch_template_name" {
+  description = "The name of the launch template"
+  value       = module.complete.launch_template_name
+}
+
 output "complete_launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = module.complete.launch_template_latest_version
+}
+
+output "complete_launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = module.complete.launch_template_default_version
 }
 
 output "complete_autoscaling_group_id" {
@@ -293,9 +333,19 @@ output "mixed_instance_launch_template_arn" {
   value       = module.mixed_instance.launch_template_arn
 }
 
+output "mixed_instance_launch_template_name" {
+  description = "The name of the launch template"
+  value       = module.mixed_instance.launch_template_name
+}
+
 output "mixed_instance_launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = module.mixed_instance.launch_template_latest_version
+}
+
+output "mixed_instance_launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = module.mixed_instance.launch_template_default_version
 }
 
 output "mixed_instance_autoscaling_group_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,9 +12,19 @@ output "launch_template_arn" {
   value       = try(aws_launch_template.this[0].arn, "")
 }
 
+output "launch_template_name" {
+  description = "The name of the launch template"
+  value       = try(aws_launch_template.this[0].name, "")
+}
+
 output "launch_template_latest_version" {
   description = "The latest version of the launch template"
   value       = try(aws_launch_template.this[0].latest_version, "")
+}
+
+output "launch_template_default_version" {
+  description = "The default version of the launch template"
+  value       = try(aws_launch_template.this[0].default_version, "")
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Add outputs for launch template name and default version

## Motivation and Context
- Commonly used attributes used by downstream components when using launch templates only (no ASG created)

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
