### PR TITLE
feat: Add support for ASG `maintenance_options` and LT `instance_requirements`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.1
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.14 |
 
 ## Modules
 
@@ -276,7 +276,8 @@ No modules.
 | <a name="input_instance_market_options"></a> [instance\_market\_options](#input\_instance\_market\_options) | The market (purchasing) option for the instance | `any` | `{}` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name that is propogated to launched EC2 instances via a tag - if not provided, defaults to `var.name` | `string` | `""` | no |
 | <a name="input_instance_refresh"></a> [instance\_refresh](#input\_instance\_refresh) | If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated | `any` | `{}` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance to launch | `string` | `""` | no |
+| <a name="input_instance_requirements"></a> [instance\_requirements](#input\_instance\_requirements) | The attribute requirements for the type of instance. If present then `instance_type` cannot be present | `any` | `{}` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance. If present then `instance_requirements` cannot be present | `string` | `null` | no |
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | The kernel ID | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name that should be used for the instance | `string` | `null` | no |
 | <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Name of an existing launch template to be used (created outside of this module) | `string` | `null` | no |
@@ -286,6 +287,7 @@ No modules.
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version. Can be version number, `$Latest`, or `$Default` | `string` | `null` | no |
 | <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `{}` | no |
 | <a name="input_load_balancers"></a> [load\_balancers](#input\_load\_balancers) | A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers. For ALBs, use `target_group_arns` instead | `list(string)` | `[]` | no |
+| <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
 | <a name="input_max_instance_lifetime"></a> [max\_instance\_lifetime](#input\_max\_instance\_lifetime) | The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 86400 and 31536000 seconds | `number` | `null` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | The maximum size of the autoscaling group | `number` | `null` | no |
 | <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options for the instance | `map(string)` | `{}` | no |
@@ -327,6 +329,7 @@ No modules.
 | <a name="output_autoscaling_group_availability_zones"></a> [autoscaling\_group\_availability\_zones](#output\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_autoscaling_group_default_cooldown"></a> [autoscaling\_group\_default\_cooldown](#output\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
 | <a name="output_autoscaling_group_desired_capacity"></a> [autoscaling\_group\_desired\_capacity](#output\_autoscaling\_group\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the group |
+| <a name="output_autoscaling_group_enabled_metrics"></a> [autoscaling\_group\_enabled\_metrics](#output\_autoscaling\_group\_enabled\_metrics) | List of metrics enabled for collection |
 | <a name="output_autoscaling_group_health_check_grace_period"></a> [autoscaling\_group\_health\_check\_grace\_period](#output\_autoscaling\_group\_health\_check\_grace\_period) | Time after instance comes into service before checking health |
 | <a name="output_autoscaling_group_health_check_type"></a> [autoscaling\_group\_health\_check\_type](#output\_autoscaling\_group\_health\_check\_type) | EC2 or ELB. Controls how health checking is done |
 | <a name="output_autoscaling_group_id"></a> [autoscaling\_group\_id](#output\_autoscaling\_group\_id) | The autoscaling group id |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.14 |
 
 ## Modules
 
@@ -50,6 +50,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_efa"></a> [efa](#module\_efa) | ../../ | n/a |
 | <a name="module_external"></a> [external](#module\_external) | ../../ | n/a |
+| <a name="module_instance_requirements"></a> [instance\_requirements](#module\_instance\_requirements) | ../../ | n/a |
+| <a name="module_instance_requirements_accelerators"></a> [instance\_requirements\_accelerators](#module\_instance\_requirements\_accelerators) | ../../ | n/a |
 | <a name="module_launch_template_only"></a> [launch\_template\_only](#module\_launch\_template\_only) | ../../ | n/a |
 | <a name="module_mixed_instance"></a> [mixed\_instance](#module\_mixed\_instance) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
@@ -78,6 +80,7 @@ No inputs.
 | <a name="output_complete_autoscaling_group_availability_zones"></a> [complete\_autoscaling\_group\_availability\_zones](#output\_complete\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_complete_autoscaling_group_default_cooldown"></a> [complete\_autoscaling\_group\_default\_cooldown](#output\_complete\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
 | <a name="output_complete_autoscaling_group_desired_capacity"></a> [complete\_autoscaling\_group\_desired\_capacity](#output\_complete\_autoscaling\_group\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the group |
+| <a name="output_complete_autoscaling_group_enabled_metrics"></a> [complete\_autoscaling\_group\_enabled\_metrics](#output\_complete\_autoscaling\_group\_enabled\_metrics) | List of metrics enabled for collection |
 | <a name="output_complete_autoscaling_group_health_check_grace_period"></a> [complete\_autoscaling\_group\_health\_check\_grace\_period](#output\_complete\_autoscaling\_group\_health\_check\_grace\_period) | Time after instance comes into service before checking health |
 | <a name="output_complete_autoscaling_group_health_check_type"></a> [complete\_autoscaling\_group\_health\_check\_type](#output\_complete\_autoscaling\_group\_health\_check\_type) | EC2 or ELB. Controls how health checking is done |
 | <a name="output_complete_autoscaling_group_id"></a> [complete\_autoscaling\_group\_id](#output\_complete\_autoscaling\_group\_id) | The autoscaling group id |
@@ -98,6 +101,7 @@ No inputs.
 | <a name="output_default_autoscaling_group_availability_zones"></a> [default\_autoscaling\_group\_availability\_zones](#output\_default\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_default_autoscaling_group_default_cooldown"></a> [default\_autoscaling\_group\_default\_cooldown](#output\_default\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
 | <a name="output_default_autoscaling_group_desired_capacity"></a> [default\_autoscaling\_group\_desired\_capacity](#output\_default\_autoscaling\_group\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the group |
+| <a name="output_default_autoscaling_group_enabled_metrics"></a> [default\_autoscaling\_group\_enabled\_metrics](#output\_default\_autoscaling\_group\_enabled\_metrics) | List of metrics enabled for collection |
 | <a name="output_default_autoscaling_group_health_check_grace_period"></a> [default\_autoscaling\_group\_health\_check\_grace\_period](#output\_default\_autoscaling\_group\_health\_check\_grace\_period) | Time after instance comes into service before checking health |
 | <a name="output_default_autoscaling_group_health_check_type"></a> [default\_autoscaling\_group\_health\_check\_type](#output\_default\_autoscaling\_group\_health\_check\_type) | EC2 or ELB. Controls how health checking is done |
 | <a name="output_default_autoscaling_group_id"></a> [default\_autoscaling\_group\_id](#output\_default\_autoscaling\_group\_id) | The autoscaling group id |
@@ -116,6 +120,7 @@ No inputs.
 | <a name="output_external_autoscaling_group_availability_zones"></a> [external\_autoscaling\_group\_availability\_zones](#output\_external\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_external_autoscaling_group_default_cooldown"></a> [external\_autoscaling\_group\_default\_cooldown](#output\_external\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
 | <a name="output_external_autoscaling_group_desired_capacity"></a> [external\_autoscaling\_group\_desired\_capacity](#output\_external\_autoscaling\_group\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the group |
+| <a name="output_external_autoscaling_group_enabled_metrics"></a> [external\_autoscaling\_group\_enabled\_metrics](#output\_external\_autoscaling\_group\_enabled\_metrics) | List of metrics enabled for collection |
 | <a name="output_external_autoscaling_group_health_check_grace_period"></a> [external\_autoscaling\_group\_health\_check\_grace\_period](#output\_external\_autoscaling\_group\_health\_check\_grace\_period) | Time after instance comes into service before checking health |
 | <a name="output_external_autoscaling_group_health_check_type"></a> [external\_autoscaling\_group\_health\_check\_type](#output\_external\_autoscaling\_group\_health\_check\_type) | EC2 or ELB. Controls how health checking is done |
 | <a name="output_external_autoscaling_group_id"></a> [external\_autoscaling\_group\_id](#output\_external\_autoscaling\_group\_id) | The autoscaling group id |
@@ -139,6 +144,7 @@ No inputs.
 | <a name="output_mixed_instance_autoscaling_group_availability_zones"></a> [mixed\_instance\_autoscaling\_group\_availability\_zones](#output\_mixed\_instance\_autoscaling\_group\_availability\_zones) | The availability zones of the autoscale group |
 | <a name="output_mixed_instance_autoscaling_group_default_cooldown"></a> [mixed\_instance\_autoscaling\_group\_default\_cooldown](#output\_mixed\_instance\_autoscaling\_group\_default\_cooldown) | Time between a scaling activity and the succeeding scaling activity |
 | <a name="output_mixed_instance_autoscaling_group_desired_capacity"></a> [mixed\_instance\_autoscaling\_group\_desired\_capacity](#output\_mixed\_instance\_autoscaling\_group\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the group |
+| <a name="output_mixed_instance_autoscaling_group_enabled_metrics"></a> [mixed\_instance\_autoscaling\_group\_enabled\_metrics](#output\_mixed\_instance\_autoscaling\_group\_enabled\_metrics) | List of metrics enabled for collection |
 | <a name="output_mixed_instance_autoscaling_group_health_check_grace_period"></a> [mixed\_instance\_autoscaling\_group\_health\_check\_grace\_period](#output\_mixed\_instance\_autoscaling\_group\_health\_check\_grace\_period) | Time after instance comes into service before checking health |
 | <a name="output_mixed_instance_autoscaling_group_health_check_type"></a> [mixed\_instance\_autoscaling\_group\_health\_check\_type](#output\_mixed\_instance\_autoscaling\_group\_health\_check\_type) | EC2 or ELB. Controls how health checking is done |
 | <a name="output_mixed_instance_autoscaling_group_id"></a> [mixed\_instance\_autoscaling\_group\_id](#output\_mixed\_instance\_autoscaling\_group\_id) | The autoscaling group id |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -501,7 +501,7 @@ module "efa" {
 module "instance_requirements" {
   source = "../../"
 
-  # Needs https://github.com/hashicorp/terraform-provider-aws/issues/21566 for ASG
+  # TODO - needs https://github.com/hashicorp/terraform-provider-aws/issues/21566 for ASG
   create = false
 
   # Autoscaling group
@@ -564,9 +564,8 @@ module "instance_requirements" {
 module "instance_requirements_accelerators" {
   source = "../../"
 
-  # Needs https://github.com/hashicorp/terraform-provider-aws/issues/21566 for ASG
-  # Requires access to g or p instance types in your account
-  # http://aws.amazon.com/contact-us/ec2-request
+  # TODO - needs https://github.com/hashicorp/terraform-provider-aws/issues/21566 for ASG
+  # Requires access to g or p instance types in your account http://aws.amazon.com/contact-us/ec2-request
   create = false
 
   # Autoscaling group

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -121,6 +121,11 @@ output "default_autoscaling_group_target_group_arns" {
   value       = module.default.autoscaling_group_target_group_arns
 }
 
+output "default_autoscaling_group_enabled_metrics" {
+  description = "List of metrics enabled for collection"
+  value       = module.default.autoscaling_group_enabled_metrics
+}
+
 ################################################################################
 # External
 ################################################################################
@@ -213,6 +218,11 @@ output "external_autoscaling_group_load_balancers" {
 output "external_autoscaling_group_target_group_arns" {
   description = "List of Target Group ARNs that apply to this AutoScaling Group"
   value       = module.external.autoscaling_group_target_group_arns
+}
+
+output "external_autoscaling_group_enabled_metrics" {
+  description = "List of metrics enabled for collection"
+  value       = module.external.autoscaling_group_enabled_metrics
 }
 
 ################################################################################
@@ -319,6 +329,11 @@ output "complete_autoscaling_policy_arns" {
   value       = module.complete.autoscaling_policy_arns
 }
 
+output "complete_autoscaling_group_enabled_metrics" {
+  description = "List of metrics enabled for collection"
+  value       = module.complete.autoscaling_group_enabled_metrics
+}
+
 ################################################################################
 # Mixed instance policy
 ################################################################################
@@ -411,4 +426,9 @@ output "mixed_instance_autoscaling_group_load_balancers" {
 output "mixed_instance_autoscaling_group_target_group_arns" {
   description = "List of Target Group ARNs that apply to this AutoScaling Group"
   value       = module.mixed_instance.autoscaling_group_target_group_arns
+}
+
+output "mixed_instance_autoscaling_group_enabled_metrics" {
+  description = "List of metrics enabled for collection"
+  value       = module.mixed_instance.autoscaling_group_enabled_metrics
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.14"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -200,10 +200,10 @@ resource "aws_launch_template" "this" {
       }
 
       dynamic "memory_mib" {
-        for_each = try([instance_requirements.value.memory_mib], [])
+        for_each = [instance_requirements.value.memory_mib]
         content {
           max = try(memory_mib.value.max, null)
-          min = try(memory_mib.value.min, null)
+          min = memory_mib.value.min
         }
       }
 
@@ -228,10 +228,10 @@ resource "aws_launch_template" "this" {
       }
 
       dynamic "vcpu_count" {
-        for_each = try([instance_requirements.value.vcpu_count], [])
+        for_each = [instance_requirements.value.vcpu_count]
         content {
           max = try(vcpu_count.value.max, null)
-          min = try(vcpu_count.value.min, null)
+          min = vcpu_count.value.min
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,6 @@ resource "aws_launch_template" "this" {
 
   ebs_optimized = var.ebs_optimized
   image_id      = var.image_id
-  instance_type = var.instance_type
   key_name      = var.key_name
   user_data     = var.user_data
 
@@ -149,10 +148,106 @@ resource "aws_launch_template" "this" {
     }
   }
 
+  instance_type = var.instance_type
+
+  dynamic "instance_requirements" {
+    for_each = length(var.instance_requirements) > 0 ? [var.instance_requirements] : []
+    content {
+
+      dynamic "accelerator_count" {
+        for_each = try([instance_requirements.value.accelerator_count], [])
+        content {
+          max = try(accelerator_count.value.max, null)
+          min = try(accelerator_count.value.min, null)
+        }
+      }
+
+      accelerator_manufacturers = try(instance_requirements.value.accelerator_manufacturers, [])
+      accelerator_names         = try(instance_requirements.value.accelerator_names, [])
+
+      dynamic "accelerator_total_memory_mib" {
+        for_each = try([instance_requirements.value.accelerator_total_memory_mib], [])
+        content {
+          max = try(accelerator_total_memory_mib.value.max, null)
+          min = try(accelerator_total_memory_mib.value.min, null)
+        }
+      }
+
+      accelerator_types = try(instance_requirements.value.accelerator_types, [])
+      bare_metal        = try(instance_requirements.value.bare_metal, null)
+
+      dynamic "baseline_ebs_bandwidth_mbps" {
+        for_each = try([instance_requirements.value.baseline_ebs_bandwidth_mbps], [])
+        content {
+          max = try(baseline_ebs_bandwidth_mbps.value.max, null)
+          min = try(baseline_ebs_bandwidth_mbps.value.min, null)
+        }
+      }
+
+      burstable_performance   = try(instance_requirements.value.burstable_performance, null)
+      cpu_manufacturers       = try(instance_requirements.value.cpu_manufacturers, [])
+      excluded_instance_types = try(instance_requirements.value.excluded_instance_types, [])
+      instance_generations    = try(instance_requirements.value.instance_generations, [])
+      local_storage           = try(instance_requirements.value.local_storage, null)
+      local_storage_types     = try(instance_requirements.value.local_storage_types, [])
+
+      dynamic "memory_gib_per_vcpu" {
+        for_each = try([instance_requirements.value.memory_gib_per_vcpu], [])
+        content {
+          max = try(memory_gib_per_vcpu.value.max, null)
+          min = try(memory_gib_per_vcpu.value.min, null)
+        }
+      }
+
+      dynamic "memory_mib" {
+        for_each = try([instance_requirements.value.memory_mib], [])
+        content {
+          max = try(memory_mib.value.max, null)
+          min = try(memory_mib.value.min, null)
+        }
+      }
+
+      dynamic "network_interface_count" {
+        for_each = try([instance_requirements.value.network_interface_count], [])
+        content {
+          max = try(network_interface_count.value.max, null)
+          min = try(network_interface_count.value.min, null)
+        }
+      }
+
+      on_demand_max_price_percentage_over_lowest_price = try(instance_requirements.value.on_demand_max_price_percentage_over_lowest_price, null)
+      require_hibernate_support                        = try(instance_requirements.value.require_hibernate_support, null)
+      spot_max_price_percentage_over_lowest_price      = try(instance_requirements.value.spot_max_price_percentage_over_lowest_price, null)
+
+      dynamic "total_local_storage_gb" {
+        for_each = try([instance_requirements.value.total_local_storage_gb], [])
+        content {
+          max = try(total_local_storage_gb.value.max, null)
+          min = try(total_local_storage_gb.value.min, null)
+        }
+      }
+
+      dynamic "vcpu_count" {
+        for_each = try([instance_requirements.value.vcpu_count], [])
+        content {
+          max = try(vcpu_count.value.max, null)
+          min = try(vcpu_count.value.min, null)
+        }
+      }
+    }
+  }
+
   dynamic "license_specification" {
     for_each = length(var.license_specifications) > 0 ? [var.license_specifications] : []
     content {
       license_configuration_arn = license_specifications.value.license_configuration_arn
+    }
+  }
+
+  dynamic "maintenance_options" {
+    for_each = length(var.maintenance_options) > 0 ? [var.maintenance_options] : []
+    content {
+      auto_recovery = try(maintenance_options.value.auto_recovery, null)
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,6 +96,11 @@ output "autoscaling_group_target_group_arns" {
   value       = try(aws_autoscaling_group.this[0].target_group_arns, aws_autoscaling_group.idc[0].target_group_arns, [])
 }
 
+output "autoscaling_group_enabled_metrics" {
+  description = "List of metrics enabled for collection"
+  value       = try(aws_autoscaling_group.this[0].enabled_metrics, aws_autoscaling_group.idc[0].enabled_metrics, [])
+}
+
 ################################################################################
 # Autoscaling group schedule
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -242,9 +242,15 @@ variable "image_id" {
 }
 
 variable "instance_type" {
-  description = "The type of the instance to launch"
+  description = "The type of the instance. If present then `instance_requirements` cannot be present"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "instance_requirements" {
+  description = "The attribute requirements for the type of instance. If present then `instance_type` cannot be present"
+  type        = any
+  default     = {}
 }
 
 variable "key_name" {
@@ -410,6 +416,12 @@ variable "instance_market_options" {
 variable "license_specifications" {
   description = "A list of license specifications to associate with"
   type        = map(string)
+  default     = {}
+}
+
+variable "maintenance_options" {
+  description = "The maintenance options for the instance"
+  type        = any
   default     = {}
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.14"
     }
   }
 }


### PR DESCRIPTION
## Description
- Add support for autoscaling group `maintenance_options`
- Add support launch template `instance_requirements`. This works as intended for the launch template, but additional provider updates are needed for this to integrate and work with autoscaling group https://github.com/hashicorp/terraform-provider-aws/issues/21566

## Motivation and Context
- Adding support for attribute based instance selection

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
