### PR TITLE
fix: Correct type constraint of `warm_pool` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ No modules.
 | <a name="input_vpc_zone_identifier"></a> [vpc\_zone\_identifier](#input\_vpc\_zone\_identifier) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |
 | <a name="input_wait_for_capacity_timeout"></a> [wait\_for\_capacity\_timeout](#input\_wait\_for\_capacity\_timeout) | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. (See also Waiting for Capacity below.) Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | `string` | `null` | no |
 | <a name="input_wait_for_elb_capacity"></a> [wait\_for\_elb\_capacity](#input\_wait\_for\_elb\_capacity) | Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. Takes precedence over `min_elb_capacity` behavior. | `number` | `null` | no |
-| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group | `map(string)` | `{}` | no |
+| <a name="input_warm_pool"></a> [warm\_pool](#input\_warm\_pool) | If this block is configured, add a Warm Pool to the specified Auto Scaling group | `any` | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -463,6 +463,10 @@ module "warm_pool" {
     pool_state                  = "Stopped"
     min_size                    = 1
     max_group_prepared_capacity = 2
+
+    instance_reuse_policy = {
+      reuse_on_scale_in = true
+    }
   }
 
   capacity_reservation_specification = {

--- a/variables.tf
+++ b/variables.tf
@@ -219,7 +219,7 @@ variable "tags" {
 
 variable "warm_pool" {
   description = "If this block is configured, add a Warm Pool to the specified Auto Scaling group"
-  type        = map(string)
+  type        = any
   default     = {}
 }
 


### PR DESCRIPTION
## Description
The variable `warm_pool` should support strings, numbers and other maps. 

## Motivation and Context
Fixes #201.

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
