### PR TITLE
feat!: Use `launch_template_id` instead of `launch_template_name`, raise MSV of AWS provider and Terraform to 5.0 and 1.0 respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ No modules.
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | The kernel ID | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name that should be used for the instance | `string` | `null` | no |
 | <a name="input_launch_template_description"></a> [launch\_template\_description](#input\_launch\_template\_description) | Description of the launch template | `string` | `null` | no |
+| <a name="input_launch_template_id"></a> [launch\_template\_id](#input\_launch\_template\_id) | ID of an existing launch template to be used (created outside of this module) | `string` | `null` | no |
 | <a name="input_launch_template_name"></a> [launch\_template\_name](#input\_launch\_template\_name) | Name of launch template to be created | `string` | `""` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version. Can be version number, `$Latest`, or `$Default` | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ No modules.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of the instance. If present then `instance_requirements` cannot be present | `string` | `null` | no |
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | The kernel ID | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name that should be used for the instance | `string` | `null` | no |
-| <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Name of an existing launch template to be used (created outside of this module) | `string` | `null` | no |
 | <a name="input_launch_template_description"></a> [launch\_template\_description](#input\_launch\_template\_description) | Description of the launch template | `string` | `null` | no |
 | <a name="input_launch_template_name"></a> [launch\_template\_name](#input\_launch\_template\_name) | Name of launch template to be created | `string` | `""` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.57 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.57 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Note: the default behavior of the module is to create an autoscaling group and l
 
 - Create the autoscaling policies:
 
-```
+```hcl
   scaling_policies = {
     my-policy = {
       policy_type               = "TargetTrackingScaling"
@@ -251,7 +251,6 @@ No modules.
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Note: the default behavior of the module is to create an autoscaling group and l
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.57 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
 
 ## Modules
 
@@ -63,14 +63,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/ec2_capacity_reservation) | resource |
-| [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_role) | resource |
-| [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_service_linked_role) | resource |
-| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/launch_template) | resource |
-| [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/sqs_queue) | resource |
-| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/data-sources/ami) | data source |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/data-sources/availability_zones) | data source |
+| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_capacity_reservation) | resource |
+| [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -54,7 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_instance_requirements_accelerators"></a> [instance\_requirements\_accelerators](#module\_instance\_requirements\_accelerators) | ../../ | n/a |
 | <a name="module_launch_template_only"></a> [launch\_template\_only](#module\_launch\_template\_only) | ../../ | n/a |
 | <a name="module_mixed_instance"></a> [mixed\_instance](#module\_mixed\_instance) | ../../ | n/a |
-| <a name="module_step_scaling_alarm"></a> [step\_scaling\_alarm](#module\_step\_scaling\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | n/a |
+| <a name="module_step_scaling_alarm"></a> [step\_scaling\_alarm](#module\_step\_scaling\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | ~> 4.3 |
 | <a name="module_target_tracking_customized_metrics"></a> [target\_tracking\_customized\_metrics](#module\_target\_tracking\_customized\_metrics) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_warm_pool"></a> [warm\_pool](#module\_warm\_pool) | ../../ | n/a |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,14 +29,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.59 |
 
 ## Modules
 
@@ -63,14 +63,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_capacity_reservation) | resource |
-| [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
-| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
-| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/ec2_capacity_reservation) | resource |
+| [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_role) | resource |
+| [aws_iam_service_linked_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/iam_service_linked_role) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/launch_template) | resource |
+| [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/resources/sqs_queue) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/data-sources/ami) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.59/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
 
 ## Modules
 
@@ -54,6 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_instance_requirements_accelerators"></a> [instance\_requirements\_accelerators](#module\_instance\_requirements\_accelerators) | ../../ | n/a |
 | <a name="module_launch_template_only"></a> [launch\_template\_only](#module\_launch\_template\_only) | ../../ | n/a |
 | <a name="module_mixed_instance"></a> [mixed\_instance](#module\_mixed\_instance) | ../../ | n/a |
+| <a name="module_step_scaling_alarm"></a> [step\_scaling\_alarm](#module\_step\_scaling\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | n/a |
 | <a name="module_target_tracking_customized_metrics"></a> [target\_tracking\_customized\_metrics](#module\_target\_tracking\_customized\_metrics) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_warm_pool"></a> [warm\_pool](#module\_warm\_pool) | ../../ | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -937,7 +937,8 @@ resource "aws_sqs_queue" "this" {
 }
 
 module "step_scaling_alarm" {
-  source = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  version = "~> 4.3"
 
   alarm_name          = "${local.name}-step-scaling"
   alarm_description   = "Step Scaling Alarm Example"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -112,7 +112,6 @@ module "external" {
 
   # Launch template
   create_launch_template = false
-  launch_template        = aws_launch_template.this.name
 
   tags = local.tags
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -271,6 +271,23 @@ module "complete" {
         target_value = 800
       }
     }
+    scale-out = {
+      name                      = "scale-out"
+      adjustment_type           = "ExactCapacity"
+      policy_type               = "StepScaling"
+      estimated_instance_warmup = 120
+      step_adjustment = [
+        {
+          scaling_adjustment          = 1
+          metric_interval_lower_bound = 0
+          metric_interval_upper_bound = 10
+        },
+        {
+          scaling_adjustment          = 2
+          metric_interval_lower_bound = 10
+        }
+      ]
+    }
   }
 }
 
@@ -917,4 +934,21 @@ resource "aws_sqs_queue" "this" {
   name = local.name
 
   tags = local.tags
+}
+
+module "step_scaling_alarm" {
+  source = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+
+  alarm_name          = "${local.name}-step-scaling"
+  alarm_description   = "Step Scaling Alarm Example"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 40
+  period              = 300
+
+  namespace   = "AWS/EC2"
+  metric_name = "CPUUtilization"
+  statistic   = "Average"
+
+  alarm_actions = [module.complete.autoscaling_policy_arns["scale-out"]]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -112,6 +112,7 @@ module "external" {
 
   # Launch template
   create_launch_template = false
+  launch_template_id     = aws_launch_template.this.id
 
   tags = local.tags
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.59"
+      version = "4.59"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 4.59"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.59"
+      version = ">= 4.59"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 data "aws_partition" "current" {}
-data "aws_default_tags" "current" {}
 
 locals {
   create = var.create && var.putin_khuylo
@@ -9,7 +8,6 @@ locals {
   launch_template_version = var.create_launch_template && var.launch_template_version == null ? aws_launch_template.this[0].latest_version : var.launch_template_version
 
   asg_tags = merge(
-    data.aws_default_tags.current.tags,
     var.tags,
     { "Name" = coalesce(var.instance_name, var.name) },
     var.autoscaling_group_tags,

--- a/main.tf
+++ b/main.tf
@@ -353,7 +353,7 @@ resource "aws_autoscaling_group" "this" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
 
     content {
-      name    = local.launch_template
+      id      = aws_launch_template.this[0].id
       version = local.launch_template_version
     }
   }
@@ -434,8 +434,8 @@ resource "aws_autoscaling_group" "this" {
 
       launch_template {
         launch_template_specification {
-          launch_template_name = local.launch_template
-          version              = local.launch_template_version
+          launch_template_id = aws_launch_template.this[0].id
+          version            = local.launch_template_version
         }
 
         dynamic "override" {
@@ -504,7 +504,7 @@ resource "aws_autoscaling_group" "idc" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
 
     content {
-      name    = local.launch_template
+      id      = aws_launch_template.this[0].id
       version = local.launch_template_version
     }
   }
@@ -585,8 +585,8 @@ resource "aws_autoscaling_group" "idc" {
 
       launch_template {
         launch_template_specification {
-          launch_template_name = local.launch_template
-          version              = local.launch_template_version
+          launch_template_id = aws_launch_template.this[0].id
+          version            = local.launch_template_version
         }
 
         dynamic "override" {

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
   create = var.create && var.putin_khuylo
 
   launch_template_name    = coalesce(var.launch_template_name, var.name)
+  launch_template_id      = var.create_launch_template ? aws_launch_template.this[0].id : var.launch_template_id
   launch_template_version = var.create_launch_template && var.launch_template_version == null ? aws_launch_template.this[0].latest_version : var.launch_template_version
 
   asg_tags = merge(
@@ -352,7 +353,7 @@ resource "aws_autoscaling_group" "this" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
 
     content {
-      id      = aws_launch_template.this[0].id
+      id      = local.launch_template_id
       version = local.launch_template_version
     }
   }
@@ -433,7 +434,7 @@ resource "aws_autoscaling_group" "this" {
 
       launch_template {
         launch_template_specification {
-          launch_template_id = aws_launch_template.this[0].id
+          launch_template_id = local.launch_template_id
           version            = local.launch_template_version
         }
 
@@ -503,7 +504,7 @@ resource "aws_autoscaling_group" "idc" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
 
     content {
-      id      = aws_launch_template.this[0].id
+      id      = local.launch_template_id
       version = local.launch_template_version
     }
   }
@@ -584,7 +585,7 @@ resource "aws_autoscaling_group" "idc" {
 
       launch_template {
         launch_template_specification {
-          launch_template_id = aws_launch_template.this[0].id
+          launch_template_id = local.launch_template_id
           version            = local.launch_template_version
         }
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ locals {
   create = var.create && var.putin_khuylo
 
   launch_template_name    = coalesce(var.launch_template_name, var.name)
-  launch_template         = var.create_launch_template ? aws_launch_template.this[0].name : var.launch_template
   launch_template_version = var.create_launch_template && var.launch_template_version == null ? aws_launch_template.this[0].latest_version : var.launch_template_version
 
   asg_tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -910,7 +910,7 @@ resource "aws_autoscaling_policy" "this" {
   scaling_adjustment        = try(each.value.scaling_adjustment, null)
 
   dynamic "step_adjustment" {
-    for_each = try([each.value.step_adjustment], [])
+    for_each = try(each.value.step_adjustment, [])
     content {
       scaling_adjustment          = step_adjustment.value.scaling_adjustment
       metric_interval_lower_bound = try(step_adjustment.value.metric_interval_lower_bound, null)

--- a/variables.tf
+++ b/variables.tf
@@ -31,12 +31,6 @@ variable "instance_name" {
   default     = ""
 }
 
-variable "launch_template" {
-  description = "Name of an existing launch template to be used (created outside of this module)"
-  type        = string
-  default     = null
-}
-
 variable "launch_template_version" {
   description = "Launch template version. Can be version number, `$Latest`, or `$Default`"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "instance_name" {
   default     = ""
 }
 
+variable "launch_template_id" {
+  description = "ID of an existing launch template to be used (created outside of this module)"
+  type        = string
+  default     = null
+}
+
 variable "launch_template_version" {
   description = "Launch template version. Can be version number, `$Latest`, or `$Default`"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.57"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description
- `launch_template_id` is used in place of `launch_template_name`. If using an external launch template, you will need to now pass a `launch_template_id` instead of `launch_template_name`
- Minimum supported version of AWS provider raised to `v5.0` and Terraform raised to `v1.0`
- Previously `scaling_policies` `step_adjustment` argument accepted a single map and has since changed to accept multiple maps of scaling step adjustments

In case the value of `launch_template_name` changes, a new launch template will be created but the auto scaling group still points to the old launch template. 

If you execute `terraform apply` a second time, the auto scaling group tries to change the name of the launch template, but keeps the id of the old launch template which is not valid anymore. 

Using the `launch_template_id` instead of `launch_template_name` everything is working as expected. 

## Motivation and Context
- Resolves #202.
- Resolves #236
- Closes #240

## Breaking Changes
- Yes;
	- `launch_template_id` is used in place of `launch_template_name`. If using an external launch template, you will need to now pass a `launch_template_id` instead of `launch_template_name`
	- Minimum supported version of AWS provider raised to `v5.0` and Terraform raised to `v1.0`
	- Previously `scaling_policies` `step_adjustment` argument accepted a single map and has since changed to accept multiple maps of scaling step adjustments
	
## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
