### PR TITLE
fix: Ensure resource exists so that destroy command works properly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
   create = var.create && var.putin_khuylo
 
   launch_template_name    = coalesce(var.launch_template_name, var.name)
-  launch_template         = var.create_launch_template && aws_launch_template.this ? aws_launch_template.this[0].name : var.launch_template
-  launch_template_version = var.create_launch_template && var.launch_template_version == null && aws_launch_template.this ? aws_launch_template.this[0].latest_version : var.launch_template_version
+  launch_template         = var.create_launch_template && aws_launch_template.this != null ? aws_launch_template.this[0].name : var.launch_template
+  launch_template_version = var.create_launch_template && var.launch_template_version == null && aws_launch_template.this != null ? aws_launch_template.this[0].latest_version : var.launch_template_version
 
   asg_tags = merge(
     data.aws_default_tags.current.tags,
@@ -21,7 +21,7 @@ locals {
 ################################################################################
 
 locals {
-  iam_instance_profile_arn  = var.create_iam_instance_profile && aws_iam_instance_profile.this ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
+  iam_instance_profile_arn  = var.create_iam_instance_profile && aws_iam_instance_profile.this != null ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
   iam_instance_profile_name = !var.create_iam_instance_profile && var.iam_instance_profile_arn == null ? var.iam_instance_profile_name : null
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ locals {
   create = var.create && var.putin_khuylo
 
   launch_template_name    = coalesce(var.launch_template_name, var.name)
-  launch_template         = var.create_launch_template ? aws_launch_template.this[0].name : var.launch_template
-  launch_template_version = var.create_launch_template && var.launch_template_version == null ? aws_launch_template.this[0].latest_version : var.launch_template_version
+  launch_template         = var.create_launch_template && aws_launch_template.this ? aws_launch_template.this[0].name : var.launch_template
+  launch_template_version = var.create_launch_template && var.launch_template_version == null && aws_launch_template.this ? aws_launch_template.this[0].latest_version : var.launch_template_version
 
   asg_tags = merge(
     data.aws_default_tags.current.tags,
@@ -21,7 +21,7 @@ locals {
 ################################################################################
 
 locals {
-  iam_instance_profile_arn  = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
+  iam_instance_profile_arn  = var.create_iam_instance_profile && aws_iam_instance_profile.this ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
   iam_instance_profile_name = !var.create_iam_instance_profile && var.iam_instance_profile_arn == null ? var.iam_instance_profile_name : null
 }
 


### PR DESCRIPTION
## Description
Ensure that ressource exist before referencing it so that destroy command works properly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-autoscaling/issues/215

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
