### PR TITLE
fix: use try for instance_requirements to avoid null error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ resource "aws_launch_template" "this" {
   instance_type = var.instance_type
 
   dynamic "instance_requirements" {
-    for_each = length(var.instance_requirements) > 0 ? [var.instance_requirements] : []
+    for_each = try(length(var.instance_requirements), 0) > 0 ? [var.instance_requirements] : []
     content {
 
       dynamic "accelerator_count" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- use try for instance_requirements to avoid null error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The issue is when we try to create logic to either use the `instance_type` or use `instance_requirements`

```hcl
module "default" {
  source  = "terraform-aws-modules/autoscaling/aws"
  version = "6.7.1"

  # ...

  instance_requirements = var.instance_type == null ? {
    accelerator_count = {
      max = var.accelerator_count
    }

    instance_generations    = ["current"]

    # ...
  } : null
```

The `null` cannot be changed to `{}` or it will trigger an error

If the `instance_type` is left as `null` then it will cause an issue when trying to do the `length(null)` which is why I am proposing the `try()`

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
