### PR TITLE
Add auto_rollback feature to this module in instance_refresh settings

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,7 +72,7 @@ module "complete" {
       checkpoint_percentages = [35, 70, 100]
       instance_warmup        = 300
       min_healthy_percentage = 50
-      auto_rollback = true
+      auto_rollback          = true
     }
     triggers = ["tag"]
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,6 +72,7 @@ module "complete" {
       checkpoint_percentages = [35, 70, 100]
       instance_warmup        = 300
       min_healthy_percentage = 50
+      auto_rollback = true
     }
     triggers = ["tag"]
   }

--- a/main.tf
+++ b/main.tf
@@ -679,6 +679,7 @@ resource "aws_autoscaling_group" "idc" {
           checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
           instance_warmup        = try(preferences.value.instance_warmup, null)
           min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback          = try(preferences.value.auto_rollback, null)
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -415,6 +415,7 @@ resource "aws_autoscaling_group" "this" {
           checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
           instance_warmup        = try(preferences.value.instance_warmup, null)
           min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback          = try(preferences.value.auto_rollback, null)
         }
       }
     }


### PR DESCRIPTION
## Description
Add auto_rollback feature to this module in instance_refresh settings

## Motivation and Context
Spacelift uses [this](https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2) module and we are enabling instance refresh on our private worker but auto_rollback is missing in this module so with this pr is all about adding auto_rollback feature to this module.

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
![image](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/assets/30564726/6391dcc1-34b8-4395-afbb-c591ced7726a)

