### PR TITLE
fix: Removed deprecated option and updated readme - asg deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ module "asg" {
 
   instance_market_options = {
     market_type = "spot"
-    spot_options = {
-      block_duration_minutes = 60
-    }
   }
 
   metadata_options = {

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,6 @@ resource "aws_launch_template" "this" {
       dynamic "spot_options" {
         for_each = try([instance_market_options.value.spot_options], [])
         content {
-          block_duration_minutes         = try(spot_options.value.block_duration_minutes, null)
           instance_interruption_behavior = try(spot_options.value.instance_interruption_behavior, null)
           max_price                      = try(spot_options.value.max_price, null)
           spot_instance_type             = try(spot_options.value.spot_instance_type, null)


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html

## Description
block_duration_minutes spot instances option is deprecated

## Motivation and Context
Removing a deprecated option from request_spot_instances API


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> no
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
