### PR TITLE
fix: Added all instance refresh options, including scale in protection and standby instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ module "asg" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
-      checkpoint_delay       = 600
-      checkpoint_percentages = [35, 70, 100]
-      instance_warmup        = 300
-      min_healthy_percentage = 50
+      checkpoint_delay             = 600
+      checkpoint_percentages       = [35, 70, 100]
+      instance_warmup              = 300
+      min_healthy_percentage       = 50
+      auto_rollback                = false
+      standby_instances            = "Wait"
+      scale_in_protected_instances = "Wait"
+      skip_matching                = false
     }
     triggers = ["tag"]
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -72,9 +72,9 @@ module "complete" {
       checkpoint_percentages       = [35, 70, 100]
       instance_warmup              = 300
       min_healthy_percentage       = 50
-      auto_rollback                = true
-      standby_instances            = "Ignore"
-      scale_in_protected_instances = "Ignore"
+      auto_rollback                = false
+      standby_instances            = "Wait"
+      scale_in_protected_instances = "Wait"
       skip_matching                = false
 
     }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -68,11 +68,15 @@ module "complete" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
-      checkpoint_delay       = 600
-      checkpoint_percentages = [35, 70, 100]
-      instance_warmup        = 300
-      min_healthy_percentage = 50
-      auto_rollback          = true
+      checkpoint_delay             = 600
+      checkpoint_percentages       = [35, 70, 100]
+      instance_warmup              = 300
+      min_healthy_percentage       = 50
+      auto_rollback                = true
+      standby_instances            = "Ignore"
+      scale_in_protected_instances = "Ignore"
+      skip_matching                = false
+
     }
     triggers = ["tag"]
   }

--- a/main.tf
+++ b/main.tf
@@ -411,11 +411,14 @@ resource "aws_autoscaling_group" "this" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
-          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
-          instance_warmup        = try(preferences.value.instance_warmup, null)
-          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
-          auto_rollback          = try(preferences.value.auto_rollback, null)
+          checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup              = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage       = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback                = try(preferences.value.auto_rollback, null)
+          scale_in_protected_instances = try(preferences.value.scale_in_protected_instances, null)
+          standby_instances            = try(preferences.value.standby_instances, null)
+          skip_matching                = try(preferences.value.skip_matching, null)
         }
       }
     }
@@ -675,11 +678,14 @@ resource "aws_autoscaling_group" "idc" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
-          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
-          instance_warmup        = try(preferences.value.instance_warmup, null)
-          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
-          auto_rollback          = try(preferences.value.auto_rollback, null)
+          checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup              = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage       = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback                = try(preferences.value.auto_rollback, null)
+          scale_in_protected_instances = try(preferences.value.scale_in_protected_instances, null)
+          standby_instances            = try(preferences.value.standby_instances, null)
+          skip_matching                = try(preferences.value.skip_matching, null)
         }
       }
     }


### PR DESCRIPTION

## Description
Not all preferences were available in the `instance_refresh` map. I've added the rest of them in. 

## Motivation and Context
I was getting the below error when using the module:

```
ValidationError: 2 validation errors detected: Value '' at 'preferences.scaleInProtectedInstances' failed to satisfy constraint: Member must satisfy enum value set: [Ignore, Wait, Refresh]; Value '' at 'preferences.standbyInstances' failed to satisfy constraint: Member must satisfy enum value set: [Terminate, Ignore, Wait]
```

## Breaking Changes
Since all parameters are optional. There are no breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
