### PR TITLE
feat: Instance refresh preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.16.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.16.2 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.17 |
 
 ## Modules
 
@@ -298,6 +298,7 @@ No modules.
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_ignore_desired_capacity_changes"></a> [ignore\_desired\_capacity\_changes](#input\_ignore\_desired\_capacity\_changes) | Determines whether the `desired_capacity` value is ignored after initial apply. See README note for more details | `bool` | `false` | no |
+| <a name="input_ignore_failed_scaling_activities"></a> [ignore\_failed\_scaling\_activities](#input\_ignore\_failed\_scaling\_activities) | Whether to ignore failed Auto Scaling scaling activities while waiting for capacity. The default is false -- failed scaling activities cause errors to be returned. | `bool` | `false` | no |
 | <a name="input_image_id"></a> [image\_id](#input\_image\_id) | The AMI from which to launch the instance | `string` | `""` | no |
 | <a name="input_initial_lifecycle_hooks"></a> [initial\_lifecycle\_hooks](#input\_initial\_lifecycle\_hooks) | One or more Lifecycle Hooks to attach to the Auto Scaling Group before instances are launched. The syntax is exactly the same as the separate `aws_autoscaling_lifecycle_hook` resource, without the `autoscaling_group_name` attribute. Please note that this will only work when creating a new Auto Scaling Group. For all other use-cases, please use `aws_autoscaling_lifecycle_hook` resource | `list(map(string))` | `[]` | no |
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Can be `stop` or `terminate`. (Default: `stop`) | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.16.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.16.2 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.16.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.16.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.16.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.16.2 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.17 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.17 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -68,11 +68,13 @@ module "complete" {
   instance_refresh = {
     strategy = "Rolling"
     preferences = {
-      checkpoint_delay       = 600
-      checkpoint_percentages = [35, 70, 100]
-      instance_warmup        = 300
-      min_healthy_percentage = 50
-      auto_rollback          = true
+      checkpoint_delay             = 600
+      checkpoint_percentages       = [35, 70, 100]
+      instance_warmup              = 300
+      min_healthy_percentage       = 50
+      auto_rollback                = true
+      scale_in_protected_instances = "Refresh"
+      standby_instances            = "Terminate"
     }
     triggers = ["tag"]
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.17"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.17"
+      version = "~> 5.16.2"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.16.2"
+      version = ">= 5.16.2"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -383,9 +383,10 @@ resource "aws_autoscaling_group" "this" {
   suspended_processes   = var.suspended_processes
   max_instance_lifetime = var.max_instance_lifetime
 
-  enabled_metrics         = var.enabled_metrics
-  metrics_granularity     = var.metrics_granularity
-  service_linked_role_arn = var.service_linked_role_arn
+  enabled_metrics                  = var.enabled_metrics
+  metrics_granularity              = var.metrics_granularity
+  service_linked_role_arn          = var.service_linked_role_arn
+  ignore_failed_scaling_activities = var.ignore_failed_scaling_activities
 
   dynamic "initial_lifecycle_hook" {
     for_each = var.initial_lifecycle_hooks
@@ -409,11 +410,13 @@ resource "aws_autoscaling_group" "this" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
-          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
-          instance_warmup        = try(preferences.value.instance_warmup, null)
-          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
-          auto_rollback          = try(preferences.value.auto_rollback, null)
+          checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup              = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage       = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback                = try(preferences.value.auto_rollback, null)
+          scale_in_protected_instances = try(preferences.value.scale_in_protected_instances, null)
+          standby_instances            = try(preferences.value.standby_instances, null)
         }
       }
     }
@@ -647,9 +650,10 @@ resource "aws_autoscaling_group" "idc" {
   suspended_processes   = var.suspended_processes
   max_instance_lifetime = var.max_instance_lifetime
 
-  enabled_metrics         = var.enabled_metrics
-  metrics_granularity     = var.metrics_granularity
-  service_linked_role_arn = var.service_linked_role_arn
+  enabled_metrics                  = var.enabled_metrics
+  metrics_granularity              = var.metrics_granularity
+  service_linked_role_arn          = var.service_linked_role_arn
+  ignore_failed_scaling_activities = var.ignore_failed_scaling_activities
 
   dynamic "initial_lifecycle_hook" {
     for_each = var.initial_lifecycle_hooks
@@ -673,11 +677,13 @@ resource "aws_autoscaling_group" "idc" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
-          checkpoint_delay       = try(preferences.value.checkpoint_delay, null)
-          checkpoint_percentages = try(preferences.value.checkpoint_percentages, null)
-          instance_warmup        = try(preferences.value.instance_warmup, null)
-          min_healthy_percentage = try(preferences.value.min_healthy_percentage, null)
-          auto_rollback          = try(preferences.value.auto_rollback, null)
+          checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
+          checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
+          instance_warmup              = try(preferences.value.instance_warmup, null)
+          min_healthy_percentage       = try(preferences.value.min_healthy_percentage, null)
+          auto_rollback                = try(preferences.value.auto_rollback, null)
+          scale_in_protected_instances = try(preferences.value.scale_in_protected_instances, null)
+          standby_instances            = try(preferences.value.standby_instances, null)
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -295,6 +295,12 @@ variable "autoscaling_group_tags" {
   default     = {}
 }
 
+variable "ignore_failed_scaling_activities" {
+  description = "Whether to ignore failed Auto Scaling scaling activities while waiting for capacity. The default is false -- failed scaling activities cause errors to be returned."
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Launch template
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.17"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.17"
+      version = ">= 5.16.2"
     }
   }
 }


### PR DESCRIPTION
## Description
Add `scale_in_protected_instances` and `standby_instances` to `aws_autoscaling_group` `instance_refresh.preferences`. 
Add `ignore_failed_scaling_activities`. 

## Motivation and Context
Min provider version `5.16.2` based on https://github.com/hashicorp/terraform-provider-aws/pull/33382
Additional `instance_refresh.preferences`: https://github.com/hashicorp/terraform-provider-aws/pull/33310
`ignore_failed_scaling_activities`: https://github.com/hashicorp/terraform-provider-aws/pull/32914

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
