### PR TITLE
docs: Update README to restrict max hop limit for IMDSv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,13 @@ module "asg" {
     }
   }
 
+  # This will ensure imdsv2 is enabled, required, and a single hop which is aws security
+  # best practices
+  # See https://docs.aws.amazon.com/securityhub/latest/userguide/autoscaling-controls.html#autoscaling-4
   metadata_options = {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 32
+    http_put_response_hop_limit = 1
   }
 
   network_interfaces = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
set hops to 1 as per aws recommendation

https://docs.aws.amazon.com/securityhub/latest/userguide/autoscaling-controls.html#autoscaling-4

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow best practices

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
<!--
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
-->
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have tested these changes in my own setup
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
