### PR TITLE
docs: Add note for next breaking change to remove `load_balancers` and `target_group_arns` from use

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -373,7 +373,7 @@ resource "aws_autoscaling_group" "this" {
   protect_from_scale_in     = var.protect_from_scale_in
 
   # TODO - remove at next breaking change. Use `traffic_source_identifier`/`traffic_source_type` instead
-  load_balancers            = var.load_balancers
+  load_balancers = var.load_balancers
   # TODO - remove at next breaking change. Use `traffic_source_identifier`/`traffic_source_type` instead
   target_group_arns         = var.target_group_arns
   placement_group           = var.placement_group


### PR DESCRIPTION
## Description
- Add note for next breaking change to remove `load_balancers` and `target_group_arns` from use

## Motivation and Context
- With the addition of `aws_autoscaling_traffic_source_attachment` in #248, this has introduced a second point of control for load balancer attachment which started showing up in diffs on the autoscaling group resource. In #252 we have suppressed this diff by ignoring all changes to `load_balancers` and `target_group_arns` used directly on the autoscaling group resource. In hindsight, this was not an ideal route for users. Going forward, at the next breaking change we should remove the use of `load_balancers` and `target_group_arns` and strictly use the `traffic_source_*` arguments. The `aws_autoscaling_traffic_source_attachment` is more flexible and supports more resources than what the ASG resource does directly today. You can think of the similar lifecycle that security groups and security group rules have gone through (first rules were set on the group resource, later a separate resource was added for rules only, and then later a 3rd more explicit rule resource was added - all to differentiate between the different lifecycles of the resources and their behaviors)

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
