### PR TITLE
Added option for default Name tagging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
   asg_tags = merge(
     var.tags,
-    { "Name" = coalesce(var.instance_name, var.name) },
+    (var.automatic_name_tag_apply ? { "Name" = coalesce(var.instance_name, var.name) } : {}),
     var.autoscaling_group_tags,
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -307,6 +307,11 @@ variable "instance_maintenance_policy" {
   default     = {}
 }
 
+variable "automatic_name_tag_apply" {
+  description = "If this variables is set to true, Name tag will be automatically applied to the new instances."
+  type        = bool
+  default     = true
+}
 
 ################################################################################
 # Launch template


### PR DESCRIPTION
## Description
By default, the module applies a "Name" tag and sets propagate_at_start to true with no option, to disable such behaviour. I have added an option to override this hardcoded part.

## Motivation and Context
I am using triggers and a lambda function to give newly created instances a Name tag, which is a combination of ASG name and instance ID. I cannot achieve this with having the tag hardcoded.

## Breaking Changes
No changes as the newly introduced variable default to the current behaviour. Only if one sets it to false, new changes apply.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ x ] I have executed `pre-commit run -a` on my pull request
