### PR TITLE
feat: Support Alarm Specification in Instance Refresh Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
 
 ## Modules
 
@@ -44,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | ~> 9.0 |
 | <a name="module_asg_sg"></a> [asg\_sg](#module\_asg\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_auto_rollback"></a> [auto\_rollback](#module\_auto\_rollback) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | ~> 4.3 |
 | <a name="module_complete"></a> [complete](#module\_complete) | ../../ | n/a |
 | <a name="module_default"></a> [default](#module\_default) | ../../ | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -87,6 +87,9 @@ module "complete" {
       scale_in_protected_instances = "Refresh"
       standby_instances            = "Terminate"
       skip_matching                = false
+      alarm_specification = {
+        alarms = [module.auto_rollback.cloudwatch_metric_alarm_id]
+      }
     }
     triggers = ["tag"]
   }
@@ -979,4 +982,25 @@ module "step_scaling_alarm" {
   statistic   = "Average"
 
   alarm_actions = [module.complete.autoscaling_policy_arns["scale-out"]]
+}
+
+module "auto_rollback" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
+  version = "~> 4.3"
+
+  alarm_name          = "${local.name}-auto-rollback"
+  alarm_description   = "Auto Rollback Alarm Example"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 0
+  period              = 60
+  treat_missing_data  = "notBreaching"
+
+  namespace   = "AWS/ApplicationELB"
+  metric_name = "HTTPCode_ELB_5XX_Count"
+  statistic   = "Sum"
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.46"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -420,6 +420,14 @@ resource "aws_autoscaling_group" "this" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
+
+          dynamic "alarm_specification" {
+            for_each = try([preferences.value.alarm_specification], [])
+            content {
+              alarms = alarm_specification.value.alarms
+            }
+          }
+
           checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
           checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
           instance_warmup              = try(preferences.value.instance_warmup, null)
@@ -701,6 +709,14 @@ resource "aws_autoscaling_group" "idc" {
       dynamic "preferences" {
         for_each = try([instance_refresh.value.preferences], [])
         content {
+
+          dynamic "alarm_specification" {
+            for_each = try([preferences.value.alarm_specification], [])
+            content {
+              alarms = alarm_specification.value.alarms
+            }
+          }
+
           checkpoint_delay             = try(preferences.value.checkpoint_delay, null)
           checkpoint_percentages       = try(preferences.value.checkpoint_percentages, null)
           instance_warmup              = try(preferences.value.instance_warmup, null)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.46"
     }
   }
 }


### PR DESCRIPTION
## Description
Support alarm specification in instance refresh preferences. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/36954

## Breaking Changes
No. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
