### PR TITLE
fix: Add depends_on for aws_autoscaling_policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -965,7 +965,8 @@ resource "aws_autoscaling_schedule" "this" {
 ################################################################################
 
 resource "aws_autoscaling_policy" "this" {
-  for_each = { for k, v in var.scaling_policies : k => v if local.create && var.create_scaling_policy }
+  for_each   = { for k, v in var.scaling_policies : k => v if local.create && var.create_scaling_policy }
+  depends_on = [aws_autoscaling_traffic_source_attachment.this]
 
   name                   = try(each.value.name, each.key)
   autoscaling_group_name = var.ignore_desired_capacity_changes ? aws_autoscaling_group.idc[0].name : aws_autoscaling_group.this[0].name


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Right now, it's not possible to create `aws_autoscaling_policy` because it will fail on validation (no target group attached).

```
Error: creating Auto Scaling Policy (request-count-per-target): operation error Auto Scaling: PutScalingPolicy, https response error StatusCode: 400, RequestID: xxxxxx, api error ValidationError: Target group not attached to the Auto Scaling group
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will attachment before creating the scaling policy.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
