### PR TITLE
feat: Support Launch Template `network_interfaces.connection_tracking_specification` and Autoscaling Policy `metric_stat.period`

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ Note: the default behavior of the module is to create an autoscaling group and l
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 
 ## Modules
 
@@ -331,7 +331,7 @@ No modules.
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | The minimum size of the autoscaling group | `number` | `null` | no |
 | <a name="input_mixed_instances_policy"></a> [mixed\_instances\_policy](#input\_mixed\_instances\_policy) | Configuration block containing settings to define launch targets for Auto Scaling groups | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name used across the resources created | `string` | n/a | yes |
-| <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
+| <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `any` | `[]` | no |
 | <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |
 | <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The name of the placement group into which you'll launch your instances, if any | `string` | `null` | no |
 | <a name="input_private_dns_name_options"></a> [private\_dns\_name\_options](#input\_private\_dns\_name\_options) | The options for the instance hostname. The default values are inherited from the subnet | `map(string)` | `{}` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -191,6 +191,11 @@ module "complete" {
       description           = "eth0"
       device_index          = 0
       security_groups       = [module.asg_sg.security_group_id]
+      connection_tracking_specification = {
+        tcp_established_timeout = 60
+        udp_stream_timeout      = 60
+        udp_timeout             = 60
+      }
     },
     {
       delete_on_termination = true

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82.1"
+      version = ">= 5.85"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -300,6 +300,15 @@ resource "aws_launch_template" "this" {
       # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/4570
       security_groups = compact(concat(try(network_interfaces.value.security_groups, []), var.security_groups))
       subnet_id       = try(network_interfaces.value.subnet_id, null)
+
+      dynamic "connection_tracking_specification" {
+        for_each = try([network_interfaces.value.connection_tracking_specification], [])
+        content {
+          tcp_established_timeout = try(connection_tracking_specification.value.tcp_established_timeout, null)
+          udp_stream_timeout      = try(connection_tracking_specification.value.udp_stream_timeout, null)
+          udp_timeout             = try(connection_tracking_specification.value.udp_timeout, null)
+        }
+      }
     }
   }
 
@@ -1061,8 +1070,9 @@ resource "aws_autoscaling_policy" "this" {
                     }
                   }
 
-                  stat = metric_stat.value.stat
-                  unit = try(metric_stat.value.unit, null)
+                  period = try(metric_stat.value.period, null)
+                  stat   = metric_stat.value.stat
+                  unit   = try(metric_stat.value.unit, null)
                 }
               }
 

--- a/variables.tf
+++ b/variables.tf
@@ -440,7 +440,7 @@ variable "maintenance_options" {
 
 variable "network_interfaces" {
   description = "Customize network interfaces to be attached at instance boot time"
-  type        = list(any)
+  type        = any
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82.1"
+      version = ">= 5.85"
     }
   }
 }


### PR DESCRIPTION
## Description
Support launch template `network_interfaces.connection_tracking_specification`. 
Support Autoscaling policy `metric_stat.period`. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/41066
- https://github.com/hashicorp/terraform-provider-aws/pull/41184

## Breaking Changes
No. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
