### PR TITLE
feat: Add variable for launch template only tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ No modules.
 | <a name="input_launch_template_description"></a> [launch\_template\_description](#input\_launch\_template\_description) | Description of the launch template | `string` | `null` | no |
 | <a name="input_launch_template_id"></a> [launch\_template\_id](#input\_launch\_template\_id) | ID of an existing launch template to be used (created outside of this module) | `string` | `null` | no |
 | <a name="input_launch_template_name"></a> [launch\_template\_name](#input\_launch\_template\_name) | Name of launch template to be created | `string` | `""` | no |
+| <a name="input_launch_template_tags"></a> [launch\_template\_tags](#input\_launch\_template\_tags) | A map of additional tags to add to the launch template | `map(string)` | `{}` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version. Can be version number, `$Latest`, or `$Default` | `string` | `null` | no |
 | <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -347,7 +347,7 @@ resource "aws_launch_template" "this" {
     create_before_destroy = true
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.launch_template_tags)
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -462,6 +462,12 @@ variable "tag_specifications" {
   default     = []
 }
 
+variable "launch_template_tags" {
+  description = "A map of additional tags to add to the launch template"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Autoscaling group traffic source attachment
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow to create specific tags for the launch template.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you have a EC2 Image Builder distribution configuration that automatically updates the launch template, every time you do a plan it says that will create a new version, because the tag `CreatedBy = "EC2 Image Builder"` is not present. With this we can put this tag only in the launch template (instead of putting it to autoscaling group and iam role as well).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
