### PR TITLE
feat: Add variable autoscaling_group_only_tags not propagated to the EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_autoscaling_group_only_tags"></a> [autoscaling\_group\_only\_tags](#input\_autoscaling\_group\_only\_tags) | A map of additional tags to add to the autoscaling group only, not propagated to the ec2 instances | `map(string)` | `{}` | no |
 | <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | A map of additional tags to add to the autoscaling group | `map(string)` | `{}` | no |
 | <a name="input_availability_zone_distribution"></a> [availability\_zone\_distribution](#input\_availability\_zone\_distribution) | A map of configuration for capacity distribution across availability zones | `any` | `{}` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `vpc_zone_identifier` argument. Conflicts with `vpc_zone_identifier` | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -639,6 +639,15 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
+  dynamic "tag" {
+    for_each = var.autoscaling_group_only_tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
@@ -934,6 +943,15 @@ resource "aws_autoscaling_group" "idc" {
       key                 = tag.key
       value               = tag.value
       propagate_at_launch = true
+    }
+  }
+
+  dynamic "tag" {
+    for_each = var.autoscaling_group_only_tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -468,6 +468,12 @@ variable "launch_template_tags" {
   default     = {}
 }
 
+variable "autoscaling_group_only_tags" {
+  description = "A map of additional tags to add to the autoscaling group only, not propagated to the ec2 instances"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Autoscaling group traffic source attachment
 ################################################################################


### PR DESCRIPTION
## Description
Add variable to allow adding tags to ASG without being propagated to the EC2 instances.

## Motivation and Context
We add tags to manage stop/start of EC2 instance for finops reasons. When instances managed by autoscaling group, we need the the tag to be only on the autoscaling group level to avoid conflict.

## Breaking Changes
NO

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
Tested in my workspace, I added a map of tags in the variable autoscaling_group_only_tags


- [x] I have executed `pre-commit run -a` on my pull request
juste the issue related to the [provider 6.0](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/issues/290) 
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
