### PR TITLE
fix: Remove unsupported arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,6 @@ No modules.
 | <a name="input_disable_api_stop"></a> [disable\_api\_stop](#input\_disable\_api\_stop) | If true, enables EC2 instance stop protection | `bool` | `null` | no |
 | <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 instance termination protection | `bool` | `null` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |
-| <a name="input_elastic_gpu_specifications"></a> [elastic\_gpu\_specifications](#input\_elastic\_gpu\_specifications) | The elastic GPU to attach to the instance | `map(string)` | `{}` | no |
-| <a name="input_elastic_inference_accelerator"></a> [elastic\_inference\_accelerator](#input\_elastic\_inference\_accelerator) | Configuration block containing an Elastic Inference Accelerator to attach to the instance | `map(string)` | `{}` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Enables/disables detailed monitoring | `bool` | `true` | no |
 | <a name="input_enabled_metrics"></a> [enabled\_metrics](#input\_enabled\_metrics) | A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances` | `list(string)` | `[]` | no |
 | <a name="input_enclave_options"></a> [enclave\_options](#input\_enclave\_options) | Enable Nitro Enclaves on launched instances | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -99,20 +99,6 @@ resource "aws_launch_template" "this" {
     }
   }
 
-  dynamic "elastic_gpu_specifications" {
-    for_each = length(var.elastic_gpu_specifications) > 0 ? [var.elastic_gpu_specifications] : []
-    content {
-      type = elastic_gpu_specifications.value.type
-    }
-  }
-
-  dynamic "elastic_inference_accelerator" {
-    for_each = length(var.elastic_inference_accelerator) > 0 ? [var.elastic_inference_accelerator] : []
-    content {
-      type = elastic_inference_accelerator.value.type
-    }
-  }
-
   dynamic "enclave_options" {
     for_each = length(var.enclave_options) > 0 ? [var.enclave_options] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -396,18 +396,6 @@ variable "credit_specification" {
   default     = {}
 }
 
-variable "elastic_gpu_specifications" {
-  description = "The elastic GPU to attach to the instance"
-  type        = map(string)
-  default     = {}
-}
-
-variable "elastic_inference_accelerator" {
-  description = "Configuration block containing an Elastic Inference Accelerator to attach to the instance"
-  type        = map(string)
-  default     = {}
-}
-
 variable "enclave_options" {
   description = "Enable Nitro Enclaves on launched instances"
   type        = map(string)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -25,8 +25,6 @@ module "wrapper" {
   disable_api_stop                     = try(each.value.disable_api_stop, var.defaults.disable_api_stop, null)
   disable_api_termination              = try(each.value.disable_api_termination, var.defaults.disable_api_termination, null)
   ebs_optimized                        = try(each.value.ebs_optimized, var.defaults.ebs_optimized, null)
-  elastic_gpu_specifications           = try(each.value.elastic_gpu_specifications, var.defaults.elastic_gpu_specifications, {})
-  elastic_inference_accelerator        = try(each.value.elastic_inference_accelerator, var.defaults.elastic_inference_accelerator, {})
   enable_monitoring                    = try(each.value.enable_monitoring, var.defaults.enable_monitoring, true)
   enabled_metrics                      = try(each.value.enabled_metrics, var.defaults.enabled_metrics, [])
   enclave_options                      = try(each.value.enclave_options, var.defaults.enclave_options, {})


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove arguments no longer supported by AWS Provider v6.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AWS Provider v6 no longer supports `elastic_gpu_specifications` or `elastic_inference_accelerator`. This PR allows people to use this module with v6 or higher. It is not necessary to raise the minimum version requirement as we are not using new features, only removing deprecated arguments.

See <https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.0.0>
Resolves <https://github.com/terraform-aws-modules/terraform-aws-autoscaling/issues/290>

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
