### PR TITLE
fix: Correct null check between two definitions of ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -370,7 +370,7 @@ resource "aws_autoscaling_group" "idc" {
   ignore_failed_scaling_activities = var.ignore_failed_scaling_activities
 
   dynamic "initial_lifecycle_hook" {
-    for_each = var.initial_lifecycle_hooks
+    for_each = var.initial_lifecycle_hooks != null ? var.initial_lifecycle_hooks : []
 
     content {
       default_result          = initial_lifecycle_hook.value.default_result


### PR DESCRIPTION
## Description
- Correct null check between two definitions of ASG

## Motivation and Context

```
│ Error: Invalid dynamic for_each value
│
│   on .terraform/modules/autoscaling/main.tf line 373, in resource "aws_autoscaling_group" "idc":
│  373:     for_each = var.initial_lifecycle_hooks
│     ├────────────────
│     │ var.initial_lifecycle_hooks is null
│
│ Cannot use a null value in for_each.
╵
```

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
