### PR TITLE
fix: Correct vcpu_count.min type in instance_requirements

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -571,7 +571,7 @@ variable "instance_requirements" {
     }))
     vcpu_count = optional(object({
       max = optional(number)
-      min = string
+      min = optional(number)
     }))
   })
   default = null


### PR DESCRIPTION
## Description
Corrects the type of vcpu_count.min in instance_requirements from string to optional(number) in variables.tf

## Motivation and Context
Fixes #305.

vcpu_count.min is currently defined as a string, which causes a type mismatch when users provide numeric values (as expected by AWS and Terraform)

## Breaking Changes
No, this change corrects an invalid type definition. Users are already expected to pass a numeric value, so this aligns behavior with existing usage and expectations.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
